### PR TITLE
feat: Add npx compatibility

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+
+const child = spawn('react-scripts', ['start'], {
+  stdio: 'inherit',
+  shell: true,
+  cwd: __dirname,
+});
+
+child.on('close', (code) => {
+  process.exit(code);
+});

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "fossflow-local",
   "version": "1.0",
   "private": true,
+  "bin": "cli.js",
   "dependencies": {
     "@isoflow/isopacks": "^0.0.10",
     "@testing-library/dom": "^10.4.0",


### PR DESCRIPTION
Allow to run the app using:
```bash
npx github:stan-smith/FossFLOW
```

Curretly could be run using:
```bash
npx github:adrianlzt/FossFLOW#feat/npx-compatible
```