### PR TITLE
@fatflyingpigs thanks for pointing this out, this update removes discord link, fixes gh link, I'll work on version nums, #94

### DIFF
--- a/packages/fossflow-lib/package.json
+++ b/packages/fossflow-lib/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/stan-smith/fossflow-lib.git"
+    "url": "https://github.com/stan-smith/FossFLOW.git"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/fossflow-lib/src/components/MainMenu/MainMenu.tsx
+++ b/packages/fossflow-lib/src/components/MainMenu/MainMenu.tsx
@@ -3,7 +3,6 @@ import { Menu, Typography, Divider, Card } from '@mui/material';
 import {
   Menu as MenuIcon,
   GitHub as GitHubIcon,
-  QuestionAnswer as QuestionAnswerIcon,
   DataObject as ExportJsonIcon,
   ImageOutlined as ExportImageIcon,
   FolderOpen as FolderOpenIcon,
@@ -248,17 +247,6 @@ export const MainMenu = () => {
                   GitHub
                 </MenuItem>
               )}
-
-              {mainMenuOptions.includes('LINK.DISCORD') && (
-                <MenuItem
-                  onClick={() => {
-                    return gotoUrl('https://discord.gg/QYPkvZth7D');
-                  }}
-                  Icon={<QuestionAnswerIcon />}
-                >
-                  Discord
-                </MenuItem>
-              )}
             </>
           )}
 
@@ -269,7 +257,7 @@ export const MainMenu = () => {
               {mainMenuOptions.includes('VERSION') && (
                 <MenuItem>
                   <Typography variant="body2" color="text.secondary">
-                    Isoflow v{PACKAGE_VERSION}
+                    FossFLOW v{PACKAGE_VERSION}
                   </Typography>
                 </MenuItem>
               )}

--- a/packages/fossflow-lib/webpack.config.js
+++ b/packages/fossflow-lib/webpack.config.js
@@ -62,6 +62,7 @@ module.exports = {
     }),
     new webpack.DefinePlugin({
       PACKAGE_VERSION: JSON.stringify(packageJson.version),
+      REPOSITORY_URL: JSON.stringify(packageJson.repository.url),
     }),
   ],
   externals: {


### PR DESCRIPTION
## Summary
- Removed Discord link from the hamburger menu
- Fixed GitHub repository link to point to the correct repository (https://github.com/stan-smith/FossFLOW.git)
- Changed version display from "Isoflow" to "FossFLOW" in the menu

## Related Issue
Related to #94 

## Thanks
Thanks to @fatflyingpigs for pointing out these issues!