### PR TITLE
Fix ExportImageDialog infinite re-render loop

### DIFF
--- a/packages/fossflow-lib/src/components/ExportImageDialog/ExportImageDialog.tsx
+++ b/packages/fossflow-lib/src/components/ExportImageDialog/ExportImageDialog.tsx
@@ -105,7 +105,7 @@ export const ExportImageDialog = ({ onClose, quality = 1.5 }: Props) => {
     }, 100);
 
     return () => clearTimeout(timer);
-  }, [showGrid, backgroundColor, exportImage]);
+  }, [showGrid, backgroundColor]);
 
   useEffect(() => {
     const timer = setTimeout(() => {

--- a/packages/fossflow-lib/src/components/ExportImageDialog/ExportImageDialog.tsx
+++ b/packages/fossflow-lib/src/components/ExportImageDialog/ExportImageDialog.tsx
@@ -113,7 +113,7 @@ export const ExportImageDialog = ({ onClose, quality = 1.5 }: Props) => {
     }, 100);
 
     return () => clearTimeout(timer);
-  }, [exportImage]);
+  }, []);
 
   const downloadFile = useCallback(() => {
     if (!imageData) return;

--- a/packages/fossflow-lib/src/components/ExportImageDialog/ExportImageDialog.tsx
+++ b/packages/fossflow-lib/src/components/ExportImageDialog/ExportImageDialog.tsx
@@ -73,7 +73,6 @@ export const ExportImageDialog = ({ onClose, quality = 1.5 }: Props) => {
     isExporting.current = true;
     exportAsImage(containerRef.current as HTMLDivElement)
       .then((data) => {
-        console.log('Exported image data:', data);
         setImageData(data);
         isExporting.current = false;
       })


### PR DESCRIPTION
## Description
Fixes the broken image export functionality in the ExportImageDialog component that was completely non-functional due to an infinite re-render loop.

## Problem
The `onModelUpdated={exportImage}` callback was creating an infinite cycle:
1. `onModelUpdated` fires when Isoflow's internal model changes
2. This triggers `exportImage` which modifies the DOM during export
3. DOM changes cause the Isoflow component to update its model again
4. Loop repeats infinitely

The debounce mechanism was a failed workaround that introduced timing issues where `containerRef.current` would be null by the time the delayed export executed.

## Solution
- Completely removed the optional `onModelUpdated` prop that was causing the infinite loop
- Used `useEffect` hooks to trigger exports based on actual dependency changes
- Implemented `isExporting` flag to prevent concurrent operations
- State cleanup

## Changes
- Replace `debounceRef` with `isExporting` boolean flag
- Remove `onModelUpdated` callback dependency
- Add proper state reset when export options change
- Reduce export delay from 2000ms to 100ms for better UX


## Testing
- [x] Image export works without hanging or errors
- [x] Changing grid visibility triggers new export
- [x] Changing background color triggers new export  
- [x] No infinite re-render loops in React DevTools
- [x] Download functionality works correctly
- [x] Error states are handled properly

## Fixes
Fixes #84