### PR TITLE
feat-use-specify-template

### DIFF
--- a/packages/fossflow-app/rsbuild.config.ts
+++ b/packages/fossflow-app/rsbuild.config.ts
@@ -3,6 +3,9 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
     plugins: [pluginReact()],
+    html: {
+        template: './public/index.html',
+    },
     output: {
         distPath: {
             root: 'build',


### PR DESCRIPTION
I submitted a [PR](https://github.com/stan-smith/FossFLOW/pull/44)  before, but it was not merged and was closed instead. So I am resubmitting it again

Use the specified template instead of rsbuild's default template.

Before：
<img width="993" height="523" alt="image" src="https://github.com/user-attachments/assets/0ceb9c84-f65a-4966-9e82-9661d419e8f4" />

After：
<img width="1222" height="587" alt="image" src="https://github.com/user-attachments/assets/a95480ad-8c80-4bc6-bc58-9aabb6f52371" />

