### PR TITLE
fix: remove duplicate code in ExportImageDialog

### DIFF
--- a/packages/fossflow-lib/src/components/ExportImageDialog/ExportImageDialog.tsx
+++ b/packages/fossflow-lib/src/components/ExportImageDialog/ExportImageDialog.tsx
@@ -106,26 +106,7 @@ export const ExportImageDialog = ({ onClose, quality = 1.5 }: Props) => {
 
     return () => clearTimeout(timer);
 
-  }, [showGrid, backgroundColor]);
-
-  const downloadFile = useCallback(() => {
-    if (!imageData) return;
-
-    const data = base64ToBlob(
-      imageData.replace('data:image/png;base64,', ''),
-      'image/png;charset=utf-8'
-    );
-
-    downloadFileUtil(data, generateGenericFilename('png'));
-  }, [imageData]);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      exportImage();
-    }, 100);
-
-    return () => clearTimeout(timer);
-  }, []);
+  }, [showGrid, backgroundColor, exportImage]);
 
   const downloadFile = useCallback(() => {
     if (!imageData) return;


### PR DESCRIPTION
Removes duplicate downloadFile declaration and useEffect that were causing build errors after merge.