### PR TITLE
Improve icon panel layout and accessibility for smaller screens (Issue #125)

### DIFF
--- a/packages/fossflow-lib/src/components/ItemControls/IconSelectionControls/IconSelectionControls.tsx
+++ b/packages/fossflow-lib/src/components/ItemControls/IconSelectionControls/IconSelectionControls.tsx
@@ -206,56 +206,6 @@ export const IconSelectionControls = () => {
             <Box sx={{ marginTop: '8px' }}>
               <Searchbox value={filter} onChange={setFilter} />
             </Box>
-            <Box sx={{ 
-              border: '1px solid #e0e0e0', 
-              borderRadius: 1, 
-              p: 1.5,
-              backgroundColor: '#f5f5f5'
-            }}>
-              <Button
-                variant="outlined"
-                startIcon={<FileUploadIcon />}
-                onClick={handleImportClick}
-                fullWidth
-              >
-                Import Icons
-              </Button>
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={treatAsIsometric}
-                    onChange={(e) => setTreatAsIsometric(e.target.checked)}
-                    size="small"
-                  />
-                }
-                label={
-                  <Typography variant="body2">
-                    Treat as isometric (3D view)
-                  </Typography>
-                }
-                sx={{ mt: 1, ml: 0 }}
-              />
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-                Uncheck for flat icons (logos, UI elements)
-              </Typography>
-            </Box>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              multiple
-              style={{ display: 'none' }}
-              onChange={handleFileSelect}
-            />
-            {showAlert && (
-              <Alert 
-                severity="info" 
-                onClose={dismissAlert}
-                sx={{ cursor: 'pointer' }}
-              >
-                You can drag and drop any item below onto the canvas.
-              </Alert>
-            )}
           </Stack>
         </Section>
       }
@@ -268,6 +218,61 @@ export const IconSelectionControls = () => {
       {!filteredIcons && (
         <Icons iconCategories={iconCategories} onMouseDown={onMouseDown} />
       )}
+      
+      <Section>
+        <Box sx={{ 
+          border: '1px solid #e0e0e0', 
+          borderRadius: 1, 
+          p: 1.5,
+          backgroundColor: '#f5f5f5'
+        }}>
+          <Button
+            variant="outlined"
+            startIcon={<FileUploadIcon />}
+            onClick={handleImportClick}
+            fullWidth
+          >
+            Import Icons
+          </Button>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={treatAsIsometric}
+                onChange={(e) => setTreatAsIsometric(e.target.checked)}
+                size="small"
+              />
+            }
+            label={
+              <Typography variant="body2">
+                Treat as isometric (3D view)
+              </Typography>
+            }
+            sx={{ mt: 1, ml: 0 }}
+          />
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+            Uncheck for flat icons (logos, UI elements)
+          </Typography>
+        </Box>
+        
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          style={{ display: 'none' }}
+          onChange={handleFileSelect}
+        />
+        
+        {showAlert && (
+          <Alert 
+            severity="info" 
+            onClose={dismissAlert}
+            sx={{ cursor: 'pointer', mt: 1 }}
+          >
+            You can drag and drop any item below onto the canvas.
+          </Alert>
+        )}
+      </Section>
     </ControlsContainer>
   );
 };

--- a/packages/fossflow-lib/src/components/ItemControls/IconSelectionControls/IconSelectionControls.tsx
+++ b/packages/fossflow-lib/src/components/ItemControls/IconSelectionControls/IconSelectionControls.tsx
@@ -27,6 +27,11 @@ export const IconSelectionControls = () => {
   const { iconCategories } = useIconCategories();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [treatAsIsometric, setTreatAsIsometric] = useState(true);
+  const [showAlert, setShowAlert] = useState(() => {
+    // Check localStorage to see if user has dismissed the alert
+    return localStorage.getItem('fossflow-show-drag-hint') !== 'false';
+  });
+
 
   const onMouseDown = useCallback(
     (icon: Icon) => {
@@ -43,6 +48,11 @@ export const IconSelectionControls = () => {
 
   const handleImportClick = useCallback(() => {
     fileInputRef.current?.click();
+  }, []);
+
+  const dismissAlert = useCallback(() => {
+    setShowAlert(false);
+    localStorage.setItem('fossflow-show-drag-hint', 'false');
   }, []);
 
   const handleFileSelect = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -237,9 +247,15 @@ export const IconSelectionControls = () => {
               style={{ display: 'none' }}
               onChange={handleFileSelect}
             />
-            <Alert severity="info">
-              You can drag and drop any item below onto the canvas.
-            </Alert>
+            {showAlert && (
+              <Alert 
+                severity="info" 
+                onClose={dismissAlert}
+                sx={{ cursor: 'pointer' }}
+              >
+                You can drag and drop any item below onto the canvas.
+              </Alert>
+            )}
           </Stack>
         </Section>
       }

--- a/packages/fossflow-lib/src/components/MainMenu/MainMenu.tsx
+++ b/packages/fossflow-lib/src/components/MainMenu/MainMenu.tsx
@@ -9,7 +9,8 @@ import {
   DeleteOutline as DeleteOutlineIcon,
   Undo as UndoIcon,
   Redo as RedoIcon,
-  Settings as SettingsIcon
+  Settings as SettingsIcon,
+
 } from '@mui/icons-material';
 import { UiElement } from 'src/components/UiElement/UiElement';
 import { IconButton } from 'src/components/IconButton/IconButton';
@@ -133,6 +134,9 @@ export const MainMenu = () => {
     uiStateActions.setDialog(DialogTypeEnum.SETTINGS);
   }, [uiStateActions]);
 
+
+
+
   const sectionVisibility = useMemo(() => {
     return {
       actions: Boolean(
@@ -196,6 +200,7 @@ export const MainMenu = () => {
           >
             {t('redo')}
           </MenuItem>
+
 
           {(canUndo || canRedo) && sectionVisibility.actions && <Divider />}
 

--- a/packages/fossflow-lib/src/stores/uiStateStore.tsx
+++ b/packages/fossflow-lib/src/stores/uiStateStore.tsx
@@ -35,6 +35,7 @@ const initialState = () => {
       hotkeyProfile: DEFAULT_HOTKEY_PROFILE,
       panSettings: DEFAULT_PAN_SETTINGS,
       connectorInteractionMode: 'click', // Default to click mode
+
       actions: {
         setView: (view) => {
           set({ view });
@@ -94,10 +95,10 @@ const initialState = () => {
         setEnableDebugTools: (enableDebugTools) => {
           set({ enableDebugTools });
         },
-        setRendererEl: (el) => {
+        setRendererEl: (el: HTMLDivElement) => {
           set({ rendererEl: el });
         },
-        setHotkeyProfile: (hotkeyProfile) => {
+        setHotkeyProfile: (hotkeyProfile: any) => {
           set({ hotkeyProfile });
         },
         setPanSettings: (panSettings) => {

--- a/packages/fossflow-lib/src/types/ui.ts
+++ b/packages/fossflow-lib/src/types/ui.ts
@@ -154,6 +154,7 @@ export interface UiState {
   hotkeyProfile: HotkeyProfile;
   panSettings: PanSettings;
   connectorInteractionMode: ConnectorInteractionMode;
+
 }
 
 export interface UiStateActions {
@@ -177,6 +178,7 @@ export interface UiStateActions {
   setHotkeyProfile: (profile: HotkeyProfile) => void;
   setPanSettings: (settings: PanSettings) => void;
   setConnectorInteractionMode: (mode: ConnectorInteractionMode) => void;
+
 }
 
 export type UiStateStore = UiState & {


### PR DESCRIPTION
The icon import section was taking up too much valuable screen space on smaller devices like MacBook Air (1440x900), making it difficult to browse and select icons effectively. The drag-and-drop hint also couldn't be dismissed, adding to the visual clutter. ((as mentioned in #125 


## What I Changed

### Made the drag-and-drop hint dismissible
I added a close button to the blue info alert that says "You can drag and drop any item below onto the canvas." Now users can dismiss it permanently, and their preference is saved in localStorage so it stays hidden across browser sessions.

### Moved the import section to the bottom
Instead of having the import functionality at the top of the panel, I relocated it below all the icon categories (ISOFLOW, AWS, GCP, Azure, Kubernetes). This puts the most commonly used icons front and center where users expect them.


<img width="404" height="542" alt="Screenshot 2025-09-17 234826" src="https://github.com/user-attachments/assets/3c03220e-6f8c-4510-86ce-9e65c5a89d98" />


