### PR TITLE
feat : Add real-time icon scaling to fix oversized imported icons #112

### DIFF
--- a/packages/fossflow-lib/src/components/ItemControls/IconSelectionControls/IconSelectionControls.tsx
+++ b/packages/fossflow-lib/src/components/ItemControls/IconSelectionControls/IconSelectionControls.tsx
@@ -206,56 +206,6 @@ export const IconSelectionControls = () => {
             <Box sx={{ marginTop: '8px' }}>
               <Searchbox value={filter} onChange={setFilter} />
             </Box>
-            <Box sx={{ 
-              border: '1px solid #e0e0e0', 
-              borderRadius: 1, 
-              p: 1.5,
-              backgroundColor: '#f5f5f5'
-            }}>
-              <Button
-                variant="outlined"
-                startIcon={<FileUploadIcon />}
-                onClick={handleImportClick}
-                fullWidth
-              >
-                Import Icons
-              </Button>
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={treatAsIsometric}
-                    onChange={(e) => setTreatAsIsometric(e.target.checked)}
-                    size="small"
-                  />
-                }
-                label={
-                  <Typography variant="body2">
-                    Treat as isometric (3D view)
-                  </Typography>
-                }
-                sx={{ mt: 1, ml: 0 }}
-              />
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-                Uncheck for flat icons (logos, UI elements)
-              </Typography>
-            </Box>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              multiple
-              style={{ display: 'none' }}
-              onChange={handleFileSelect}
-            />
-            {showAlert && (
-              <Alert 
-                severity="info" 
-                onClose={dismissAlert}
-                sx={{ cursor: 'pointer' }}
-              >
-                You can drag and drop any item below onto the canvas.
-              </Alert>
-            )}
           </Stack>
         </Section>
       }
@@ -268,6 +218,61 @@ export const IconSelectionControls = () => {
       {!filteredIcons && (
         <Icons iconCategories={iconCategories} onMouseDown={onMouseDown} />
       )}
+      
+      <Section>
+        <Box sx={{ 
+          border: '1px solid #e0e0e0', 
+          borderRadius: 1, 
+          p: 1.5,
+          backgroundColor: '#f5f5f5'
+        }}>
+          <Button
+            variant="outlined"
+            startIcon={<FileUploadIcon />}
+            onClick={handleImportClick}
+            fullWidth
+          >
+            Import Icons
+          </Button>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={treatAsIsometric}
+                onChange={(e) => setTreatAsIsometric(e.target.checked)}
+                size="small"
+              />
+            }
+            label={
+              <Typography variant="body2">
+                Treat as isometric (3D view)
+              </Typography>
+            }
+            sx={{ mt: 1, ml: 0 }}
+          />
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+            Uncheck for flat icons (logos, UI elements)
+          </Typography>
+        </Box>
+        
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          style={{ display: 'none' }}
+          onChange={handleFileSelect}
+        />
+        
+        {showAlert && (
+          <Alert 
+            severity="info" 
+            onClose={dismissAlert}
+            sx={{ cursor: 'pointer', mt: 1 }}
+          >
+            You can drag and drop any item below onto the canvas.
+          </Alert>
+        )}
+      </Section>
     </ControlsContainer>
   );
 };

--- a/packages/fossflow-lib/src/components/ItemControls/IconSelectionControls/IconSelectionControls.tsx
+++ b/packages/fossflow-lib/src/components/ItemControls/IconSelectionControls/IconSelectionControls.tsx
@@ -27,6 +27,11 @@ export const IconSelectionControls = () => {
   const { iconCategories } = useIconCategories();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [treatAsIsometric, setTreatAsIsometric] = useState(true);
+  const [showAlert, setShowAlert] = useState(() => {
+    // Check localStorage to see if user has dismissed the alert
+    return localStorage.getItem('fossflow-show-drag-hint') !== 'false';
+  });
+
 
   const onMouseDown = useCallback(
     (icon: Icon) => {
@@ -43,6 +48,11 @@ export const IconSelectionControls = () => {
 
   const handleImportClick = useCallback(() => {
     fileInputRef.current?.click();
+  }, []);
+
+  const dismissAlert = useCallback(() => {
+    setShowAlert(false);
+    localStorage.setItem('fossflow-show-drag-hint', 'false');
   }, []);
 
   const handleFileSelect = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -237,9 +247,15 @@ export const IconSelectionControls = () => {
               style={{ display: 'none' }}
               onChange={handleFileSelect}
             />
-            <Alert severity="info">
-              You can drag and drop any item below onto the canvas.
-            </Alert>
+            {showAlert && (
+              <Alert 
+                severity="info" 
+                onClose={dismissAlert}
+                sx={{ cursor: 'pointer' }}
+              >
+                You can drag and drop any item below onto the canvas.
+              </Alert>
+            )}
           </Stack>
         </Section>
       }

--- a/packages/fossflow-lib/src/components/ItemControls/IconSelectionControls/IconSelectionControls.tsx
+++ b/packages/fossflow-lib/src/components/ItemControls/IconSelectionControls/IconSelectionControls.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef, useState } from 'react';
-import { Stack, Alert, IconButton as MUIIconButton, Box, Button, FormControlLabel, Checkbox, Typography } from '@mui/material';
+import { Stack, Alert, IconButton as MUIIconButton, Box, Button, FormControlLabel, Checkbox, Typography, Slider } from '@mui/material';
 import { ControlsContainer } from 'src/components/ItemControls/components/ControlsContainer';
 import { useUiStateStore } from 'src/stores/uiStateStore';
 import { useModelStore } from 'src/stores/modelStore';
@@ -27,6 +27,7 @@ export const IconSelectionControls = () => {
   const { iconCategories } = useIconCategories();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [treatAsIsometric, setTreatAsIsometric] = useState(true);
+  const [iconScale, setIconScale] = useState(100);
   const [showAlert, setShowAlert] = useState(() => {
     // Check localStorage to see if user has dismissed the alert
     return localStorage.getItem('fossflow-show-drag-hint') !== 'false';
@@ -111,10 +112,11 @@ export const IconSelectionControls = () => {
             const TARGET_SIZE = 128; // Square size for consistency
             
             // Calculate scaling to fit within square while maintaining aspect ratio
-            // Remove the upper limit (1) to allow upscaling of small images
-            const scale = Math.min(TARGET_SIZE / img.width, TARGET_SIZE / img.height);
-            const scaledWidth = img.width * scale;
-            const scaledHeight = img.height * scale;
+            const basScale = Math.min(TARGET_SIZE / img.width, TARGET_SIZE / img.height);
+            // Apply user's custom scaling
+            const finalScale = basScale * (iconScale / 100);
+            const scaledWidth = img.width * finalScale;
+            const scaledHeight = img.height * finalScale;
             
             // Set canvas to square size
             canvas.width = TARGET_SIZE;
@@ -170,7 +172,7 @@ export const IconSelectionControls = () => {
 
     // Reset input
     event.target.value = '';
-  }, [currentIcons, modelActions, iconCategoriesState, uiStateActions, treatAsIsometric]);
+  }, [currentIcons, modelActions, iconCategoriesState, uiStateActions, treatAsIsometric, iconScale]);
 
   return (
     <ControlsContainer

--- a/packages/fossflow-lib/src/components/ItemControls/NodeControls/NodeSettings/NodeSettings.tsx
+++ b/packages/fossflow-lib/src/components/ItemControls/NodeControls/NodeSettings/NodeSettings.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { Slider, Box, TextField } from '@mui/material';
 import { ModelItem, ViewItem } from 'src/types';
 import { MarkdownEditor } from 'src/components/MarkdownEditor/MarkdownEditor';
 import { useModelItem } from 'src/hooks/useModelItem';
+import { useModelStore } from 'src/stores/modelStore';
 import { DeleteButton } from '../../components/DeleteButton';
 import { Section } from '../../components/Section';
 
@@ -25,6 +26,50 @@ export const NodeSettings = ({
   onDeleted
 }: Props) => {
   const modelItem = useModelItem(node.id);
+  const modelActions = useModelStore((state) => state.actions);
+  const icons = useModelStore((state) => state.icons);
+  
+  // Local state for smooth slider interaction
+  const currentIcon = icons.find(icon => icon.id === modelItem?.icon);
+  const [localScale, setLocalScale] = useState(currentIcon?.scale || 1);
+  const debounceRef = useRef<NodeJS.Timeout>();
+
+  // Update local scale when icon changes
+  useEffect(() => {
+    setLocalScale(currentIcon?.scale || 1);
+  }, [currentIcon?.scale]);
+
+  // Debounced update to store
+  const updateIconScale = useCallback((scale: number) => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+    
+    debounceRef.current = setTimeout(() => {
+      const updatedIcons = icons.map(icon => 
+        icon.id === modelItem?.icon 
+          ? { ...icon, scale }
+          : icon
+      );
+      modelActions.set({ icons: updatedIcons });
+    }, 100); // 100ms debounce
+  }, [icons, modelItem?.icon, modelActions]);
+
+  // Handle slider change with local state + debounced store update
+  const handleScaleChange = useCallback((e: Event, newScale: number | number[]) => {
+    const scale = newScale as number;
+    setLocalScale(scale); // Immediate UI update
+    updateIconScale(scale); // Debounced store update
+  }, [updateIconScale]);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
 
   if (!modelItem) {
     return null;
@@ -65,6 +110,17 @@ export const NodeSettings = ({
           />
         </Section>
       )}
+
+      <Section title="Icon size">
+        <Slider
+          marks
+          step={0.1}
+          min={0.3}
+          max={2.5}
+          value={localScale}
+          onChange={handleScaleChange}
+        />
+      </Section>
       <Section>
         <Box>
           <DeleteButton onClick={onDeleted} />

--- a/packages/fossflow-lib/src/components/MainMenu/MainMenu.tsx
+++ b/packages/fossflow-lib/src/components/MainMenu/MainMenu.tsx
@@ -9,7 +9,8 @@ import {
   DeleteOutline as DeleteOutlineIcon,
   Undo as UndoIcon,
   Redo as RedoIcon,
-  Settings as SettingsIcon
+  Settings as SettingsIcon,
+
 } from '@mui/icons-material';
 import { UiElement } from 'src/components/UiElement/UiElement';
 import { IconButton } from 'src/components/IconButton/IconButton';
@@ -133,6 +134,9 @@ export const MainMenu = () => {
     uiStateActions.setDialog(DialogTypeEnum.SETTINGS);
   }, [uiStateActions]);
 
+
+
+
   const sectionVisibility = useMemo(() => {
     return {
       actions: Boolean(
@@ -196,6 +200,7 @@ export const MainMenu = () => {
           >
             {t('redo')}
           </MenuItem>
+
 
           {(canUndo || canRedo) && sectionVisibility.actions && <Divider />}
 

--- a/packages/fossflow-lib/src/components/SceneLayers/Nodes/Node/IconTypes/IsometricIcon.tsx
+++ b/packages/fossflow-lib/src/components/SceneLayers/Nodes/Node/IconTypes/IsometricIcon.tsx
@@ -5,10 +5,11 @@ import { useResizeObserver } from 'src/hooks/useResizeObserver';
 
 interface Props {
   url: string;
+  scale?: number;
   onImageLoaded?: () => void;
 }
 
-export const IsometricIcon = ({ url, onImageLoaded }: Props) => {
+export const IsometricIcon = ({ url, scale = 1, onImageLoaded }: Props) => {
   const ref = useRef();
   const { size, observe, disconnect } = useResizeObserver();
 
@@ -28,7 +29,7 @@ export const IsometricIcon = ({ url, onImageLoaded }: Props) => {
       src={url}
       sx={{
         position: 'absolute',
-        width: PROJECTED_TILE_SIZE.width * 0.8,
+        width: PROJECTED_TILE_SIZE.width * 0.8 * scale,
         top: -size.height,
         left: -size.width / 2,
         pointerEvents: 'none'

--- a/packages/fossflow-lib/src/components/SceneLayers/Nodes/Node/IconTypes/NonIsometricIcon.tsx
+++ b/packages/fossflow-lib/src/components/SceneLayers/Nodes/Node/IconTypes/NonIsometricIcon.tsx
@@ -24,7 +24,7 @@ export const NonIsometricIcon = ({ icon }: Props) => {
           component="img"
           src={icon.url}
           alt={`icon-${icon.id}`}
-          sx={{ width: PROJECTED_TILE_SIZE.width * 0.7 }}
+          sx={{ width: PROJECTED_TILE_SIZE.width * 0.7 * (icon.scale || 1) }}
         />
       </Box>
     </Box>

--- a/packages/fossflow-lib/src/hooks/useIcon.tsx
+++ b/packages/fossflow-lib/src/hooks/useIcon.tsx
@@ -31,6 +31,7 @@ export const useIcon = (id: string | undefined) => {
     return (
       <IsometricIcon
         url={icon.url}
+        scale={icon.scale || 1}
         onImageLoaded={() => {
           setHasLoaded(true);
         }}

--- a/packages/fossflow-lib/src/schemas/icons.ts
+++ b/packages/fossflow-lib/src/schemas/icons.ts
@@ -6,7 +6,8 @@ export const iconSchema = z.object({
   name: constrainedStrings.name,
   url: z.string(),
   collection: constrainedStrings.name.optional(),
-  isIsometric: z.boolean().optional()
+  isIsometric: z.boolean().optional(),
+  scale: z.number().min(0.1).max(3).optional()
 });
 
 export const iconsSchema = z.array(iconSchema);

--- a/packages/fossflow-lib/src/stores/uiStateStore.tsx
+++ b/packages/fossflow-lib/src/stores/uiStateStore.tsx
@@ -35,6 +35,7 @@ const initialState = () => {
       hotkeyProfile: DEFAULT_HOTKEY_PROFILE,
       panSettings: DEFAULT_PAN_SETTINGS,
       connectorInteractionMode: 'click', // Default to click mode
+
       actions: {
         setView: (view) => {
           set({ view });
@@ -94,10 +95,10 @@ const initialState = () => {
         setEnableDebugTools: (enableDebugTools) => {
           set({ enableDebugTools });
         },
-        setRendererEl: (el) => {
+        setRendererEl: (el: HTMLDivElement) => {
           set({ rendererEl: el });
         },
-        setHotkeyProfile: (hotkeyProfile) => {
+        setHotkeyProfile: (hotkeyProfile: any) => {
           set({ hotkeyProfile });
         },
         setPanSettings: (panSettings) => {

--- a/packages/fossflow-lib/src/types/ui.ts
+++ b/packages/fossflow-lib/src/types/ui.ts
@@ -154,6 +154,7 @@ export interface UiState {
   hotkeyProfile: HotkeyProfile;
   panSettings: PanSettings;
   connectorInteractionMode: ConnectorInteractionMode;
+
 }
 
 export interface UiStateActions {
@@ -177,6 +178,7 @@ export interface UiStateActions {
   setHotkeyProfile: (profile: HotkeyProfile) => void;
   setPanSettings: (settings: PanSettings) => void;
   setConnectorInteractionMode: (mode: ConnectorInteractionMode) => void;
+
 }
 
 export type UiStateStore = UiState & {


### PR DESCRIPTION
Imported SVG icons were appearing significantly larger than built-in icons, creating visual inconsistency in diagrams. This was particularly noticeable with non-isometric icons like logos and UI elements, which would dominate the canvas and look disproportionate next to the default AWS, GCP, Azure, and Kubernetes icon collections. Users had no way to adjust icon sizes after import, forcing them to either accept oversized icons or avoid importing custom icons altogether. (as mentioned in #112)



<img width="600" height="340" alt="Screenshot 2025-09-19 015451" src="https://github.com/user-attachments/assets/67659486-98e5-4eab-9a7a-2256e98c3ede" />


## What I Changed

**Added real-time icon scaling slider**
I implemented an "Icon size" slider in the node settings panel, positioned below the existing "Label height" slider. Users can now scale any icon from 30% to 250% with immediate visual feedback. The slider includes marks/dots for precise control and matches the existing UI design patterns.

**Optimized for smooth performance**
To prevent frame drops during slider interaction, I used a debounced update strategy. The slider responds immediately using local component state, but only commits changes to the global store after 100ms of inactivity. This ensures smooth dragging while minimizing expensive re-renders of the entire icon system.

**Enhanced icon schema and rendering**
I added an optional `scale` property to the icon schema and updated both isometric and non-isometric icon rendering components to apply the scaling multiplier. The scaling is fully backward compatible - existing icons default to 100% scale, and the scale values persist when saving and exporting diagrams.


