### PR TITLE
fix: resolve issue #198 where moving sliders pan view

### DIFF
--- a/packages/fossflow-lib/src/components/ItemControls/components/ControlsContainer.tsx
+++ b/packages/fossflow-lib/src/components/ItemControls/components/ControlsContainer.tsx
@@ -9,6 +9,8 @@ interface Props {
 export const ControlsContainer = ({ header, children }: Props) => {
   return (
     <Box
+      onMouseDown={e => e.stopPropagation()}
+      onContextMenu={e => e.stopPropagation()}
       sx={{
         position: 'relative',
         height: '100%',


### PR DESCRIPTION
The mousedown event inside controls container (`ControlsContainer.tsx`'s children) was bubbling out to the view area.
For #198 , just one line added `stopPropagation` for mousedown.

However I also noticed that the regular browser context menu was being overridden by the view context menu, which would prevent copy/pasting in the name and description fields. So I added `stopPropagation` for contextmenu event as well.