### PR TITLE
feat: Add labels to icons indicating if not isometric (flat)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,4 @@
     "editor.defaultFormatter": "dbaeumer.vscode-eslint",
     "editor.formatOnSave": true,
     "vs-code-prettier-eslint.prettierLast": false,
-    "[typescriptreact]": {
-        "editor.defaultFormatter": "vscode.typescript-language-features"
-    },
 }


### PR DESCRIPTION
Added label for differentiating between isometric and non, as requested in #152 

In the issue, the author requested some label to be added to icons that are imported as isometric. However, here I've done the opposite, I've added the label 'flat' to non-isometric icons. My thoughts were that
- user would just see the isometric icon being isometric (3D looking), wouldnt need a label to specify that. Besides, this is the default option, and the icon is placed on the tile unmodified
- the non isometric icons _are_ the ones being modified (i.e. spread out on the tile). So a label indicating that its flat can be useful

What do you think? Ofcourse we can do the opposite too pretty easily, just need to change the label to 'iso' or '3D' and change the condition