### PR TITLE
docs: fix ~40 incorrect icon IDs in LLM generation guide

### DIFF
--- a/LLM-GENERATION-GUIDE.md
+++ b/LLM-GENERATION-GUIDE.md
@@ -45,115 +45,136 @@ Each view contains:
 
 ## Available Icons
 
-### Basic Icons (ISOFLOW Collection)
-Common icons for general use:
-- `storage` - Database/storage
+### Basic Icons (ISOFLOW Collection — 37 icons)
+Common isometric icons for general use. For the complete list, see `icon-list-generation-guide.md`.
 - `server` - Generic server
-- `user` - User/person
-- `cloud` - Cloud services
-- `network` - Network component
-- `security` - Security/firewall
-- `api` - API/interface
-- `queue` - Message queue
+- `storage` - Database/storage
 - `cache` - Caching system
-- `function` - Function/lambda
-- `mobile` - Mobile device
-- `web` - Web application
-- `email` - Email service
-- `analytics` - Analytics/monitoring
-- `backup` - Backup system
-- `load-balancer` - Load balancer
-- `cdn` - Content delivery network
-- `vpn` - VPN connection
-- `firewall` - Firewall/security
-- `monitor` - Monitoring system
+- `cloud` - Cloud services, external APIs
+- `cube` - Generic service, application
+- `block` - Generic component, module
+- `desktop` - Client, browser, workstation
+- `laptop` - Client device, developer
+- `mobiledevice` - Mobile device
+- `diamond` - Decision point, router, gateway
+- `firewall` - Firewall, security, validation
+- `lock` - Authentication, encryption
+- `function-module` - Function, Lambda, API handler
+- `package-module` - Package, library, dependency
+- `switch-module` - Switch, toggle, routing
+- `loadbalancer` - Load balancer, traffic distribution
+- `queue` - Message queue (SQS, RabbitMQ)
+- `router` - Network router, API router
+- `dns` - DNS, domain resolution, search
+- `user` - User, person, identity
+- `mail` - Email, notifications
+- `mailmultiple` - Batch email, message queue
+- `document` - File, document, config
+- `sphere` - Global, CDN, distribution
+- `vm` - Virtual machine, container
+- `cronjob` - Scheduled tasks, background jobs
+- `speech` - Chat, webhook, communication
+- `tower` - Infrastructure, broadcast
+- `truck` - CI/CD, delivery pipeline
+- `pyramid` - Hierarchy, aggregation
+- `image` - Media, image processing
+- `office` - Organization, company
+- `printer` - Output, reporting
+- `cardterminal` - Payment processing
+- `paymentcard` - Payment, billing
+- `plane` - Deployment, delivery
 
 ### AWS Icons (320 available)
-Use `aws-` prefix for AWS services:
+Use `aws-` prefix for AWS services. For the full list, see `icon-list-generation-guide.md`.
 - `aws-ec2` - EC2 instances
-- `aws-s3` - S3 storage
+- `aws-simple-storage-service` - S3 storage
 - `aws-rds` - RDS database
 - `aws-lambda` - Lambda functions
 - `aws-api-gateway` - API Gateway
 - `aws-cloudfront` - CloudFront CDN
 - `aws-route-53` - Route 53 DNS
-- `aws-vpc` - Virtual Private Cloud
-- `aws-elb` - Load balancer
-- `aws-iam` - Identity management
+- `aws-elastic-load-balancing` - Load balancer
+- `aws-identity-and-access-management` - IAM
 - `aws-cloudwatch` - Monitoring
-- `aws-sns` - Simple notification
-- `aws-sqs` - Simple queue
+- `aws-simple-notification-service` - SNS notifications
+- `aws-simple-queue-service` - SQS queues
 - `aws-dynamodb` - DynamoDB database
-- `aws-elasticsearch` - Elasticsearch
+- `aws-opensearch-service` - OpenSearch (Elasticsearch)
 - `aws-redshift` - Data warehouse
 - `aws-kinesis` - Data streaming
-- `aws-eks` - Kubernetes service
+- `aws-elastic-kubernetes-service` - EKS
 - `aws-fargate` - Container service
 - `aws-cognito` - User authentication
+- `aws-elasticache` - ElastiCache
+- `aws-aurora` - Aurora database
+- `aws-step-functions` - Step Functions
+- `aws-secrets-manager` - Secrets Manager
 
 ### Azure Icons (369 available)
-Use `azure-` prefix for Azure services:
+Use `azure-` prefix for Azure services. For the full list, see `icon-list-generation-guide.md`.
 - `azure-virtual-machine` - Virtual machines
-- `azure-storage-account` - Storage
+- `azure-storage-accounts` - Storage
 - `azure-sql-database` - SQL database
-- `azure-app-service` - Web apps
-- `azure-function-app` - Functions
-- `azure-api-management` - API management
-- `azure-cdn` - Content delivery
-- `azure-dns` - DNS service
-- `azure-load-balancer` - Load balancer
+- `azure-app-services` - Web apps
+- `azure-function-apps` - Functions
+- `azure-api-management-services` - API management
+- `azure-cdn-profiles` - Content delivery
+- `azure-dns-zones` - DNS service
+- `azure-load-balancers` - Load balancer
 - `azure-active-directory` - Identity
 - `azure-monitor` - Monitoring
 - `azure-service-bus` - Message bus
 - `azure-cosmos-db` - NoSQL database
-- `azure-redis-cache` - Redis cache
-- `azure-kubernetes-service` - Kubernetes
+- `azure-cache-redis` - Redis cache
+- `azure-kubernetes-services` - Kubernetes
 - `azure-container-instances` - Containers
 - `azure-logic-apps` - Logic apps
 - `azure-data-factory` - Data pipeline
-- `azure-key-vault` - Key management
+- `azure-key-vaults` - Key management
 - `azure-cognitive-services` - AI services
 
 ### GCP Icons (280 available)
-Use `gcp-` prefix for Google Cloud services:
+Use `gcp-` prefix for Google Cloud services. For the full list, see `icon-list-generation-guide.md`.
 - `gcp-compute-engine` - Virtual machines
 - `gcp-cloud-storage` - Storage
 - `gcp-cloud-sql` - SQL database
 - `gcp-app-engine` - Web apps
 - `gcp-cloud-functions` - Functions
-- `gcp-api-gateway` - API gateway
+- `gcp-cloud-api-gateway` - API gateway
 - `gcp-cloud-cdn` - Content delivery
 - `gcp-cloud-dns` - DNS service
 - `gcp-cloud-load-balancing` - Load balancer
-- `gcp-identity-access-management` - IAM
+- `gcp-identity-and-access-management` - IAM
 - `gcp-cloud-monitoring` - Monitoring
-- `gcp-cloud-pub-sub` - Message queue
-- `gcp-cloud-firestore` - NoSQL database
+- `gcp-pubsub` - Message queue (Pub/Sub)
+- `gcp-firestore` - NoSQL database
 - `gcp-memorystore` - Redis cache
-- `gcp-kubernetes-engine` - Kubernetes
+- `gcp-google-kubernetes-engine` - GKE
 - `gcp-cloud-run` - Container service
-- `gcp-cloud-workflows` - Workflows
-- `gcp-cloud-dataflow` - Data pipeline
+- `gcp-workflows` - Workflows
+- `gcp-dataflow` - Data pipeline
 - `gcp-secret-manager` - Secret management
 - `gcp-ai-platform` - AI/ML platform
 
 ### Kubernetes Icons (56 available)
-Use `k8s-` prefix for Kubernetes resources:
+Use `k8s-` prefix for Kubernetes resources. For the full list, see `icon-list-generation-guide.md`.
 - `k8s-pod` - Pods
-- `k8s-service` - Services
-- `k8s-deployment` - Deployments
-- `k8s-configmap` - ConfigMaps
+- `k8s-svc` - Services
+- `k8s-deploy` - Deployments
+- `k8s-cm` - ConfigMaps
 - `k8s-secret` - Secrets
-- `k8s-ingress` - Ingress
-- `k8s-namespace` - Namespaces
+- `k8s-ing` - Ingress
+- `k8s-ns` - Namespaces
 - `k8s-node` - Nodes
-- `k8s-persistent-volume` - Storage
-- `k8s-daemonset` - DaemonSets
-- `k8s-statefulset` - StatefulSets
+- `k8s-pv` - Persistent Volumes
+- `k8s-pvc` - Persistent Volume Claims
+- `k8s-ds` - DaemonSets
+- `k8s-sts` - StatefulSets
 - `k8s-job` - Jobs
 - `k8s-cronjob` - CronJobs
-- `k8s-hpa` - Auto-scaling
-- `k8s-rbac` - Role-based access
+- `k8s-hpa` - Horizontal Pod Autoscaler
+- `k8s-role` - Roles
+- `k8s-sa` - Service Accounts
 
 ## Positioning System
 
@@ -166,8 +187,40 @@ The positioning system uses a grid-based coordinate system:
 ### Positioning Guidelines:
 - Start with main components around (0, 0)
 - Place related components close together
-- Use consistent spacing (3-5 units between components)
-- Arrange in logical flow (left to right, top to bottom)
+- Use consistent spacing (3-5 units between connected nodes, 5+ between parallel branches)
+- Arrange in logical flow (top to bottom for pipelines, left to right for horizontal architectures)
+- Avoid placing two items at the same coordinates
+
+### Common Layout Patterns:
+
+**Linear Pipeline (vertical):**
+```
+[Source]      (0, -8)
+   |
+[Process]     (0, -4)
+   |
+[Output]      (0, 0)
+```
+
+**Fan-out (branching):**
+```
+           [Source]              (0, -4)
+         /    |    \
+[Branch A] [Branch B] [Branch C]
+(-6, 0)    (0, 0)     (6, 0)
+```
+
+**Layered Architecture:**
+```
+[Client]              (-6, -6)  [Client 2]    (6, -6)
+            \         /
+          [Load Balancer]        (0, -2)
+          /           \
+[Service A]          [Service B]
+(-4, 2)               (4, 2)
+          \           /
+          [Database]              (0, 6)
+```
 
 ## Connection Guidelines
 
@@ -190,8 +243,8 @@ Connections are defined as `[fromIndex, toIndex]` pairs:
 {
   "t": "Simple Web App Architecture",
   "i": [
-    ["Web App", "web", "Frontend application"],
-    ["API Gateway", "api", "API management layer"],
+    ["Web App", "desktop", "Frontend application"],
+    ["API Gateway", "diamond", "API management layer"],
     ["Database", "storage", "User data storage"],
     ["Cache", "cache", "Redis caching layer"]
   ],
@@ -215,7 +268,7 @@ Connections are defined as `[fromIndex, toIndex]` pairs:
     ["API Gateway", "aws-api-gateway", "API management"],
     ["Lambda", "aws-lambda", "Serverless functions"],
     ["DynamoDB", "aws-dynamodb", "NoSQL database"],
-    ["S3", "aws-s3", "Static file storage"]
+    ["S3", "aws-simple-storage-service", "Static file storage"]
   ],
   "v": [
     [
@@ -233,11 +286,11 @@ Connections are defined as `[fromIndex, toIndex]` pairs:
 {
   "t": "Kubernetes Application",
   "i": [
-    ["Ingress", "k8s-ingress", "Traffic routing"],
+    ["Ingress", "k8s-ing", "Traffic routing"],
     ["Frontend", "k8s-pod", "React application"],
-    ["API Service", "k8s-service", "Backend API"],
+    ["API Service", "k8s-svc", "Backend API"],
     ["Database", "k8s-pod", "PostgreSQL database"],
-    ["ConfigMap", "k8s-configmap", "Configuration data"]
+    ["ConfigMap", "k8s-cm", "Configuration data"]
   ],
   "v": [
     [

--- a/integrations/claude-code-skill/README.md
+++ b/integrations/claude-code-skill/README.md
@@ -1,0 +1,52 @@
+# FossFLOW Diagram Generator — Claude Code Skill
+
+A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill that generates valid FossFLOW isometric diagrams from natural language descriptions.
+
+## What It Does
+
+- Generates FossFLOW-compatible JSON diagrams (compact format)
+- Knows all 1,062 available icons (ISOFLOW, AWS, Azure, GCP, Kubernetes)
+- Applies layout best practices for readable isometric diagrams
+- Can analyze codebases to generate architecture diagrams automatically
+
+## Installation
+
+Copy the skill into your project's `.claude/skills/` directory:
+
+```bash
+# From the FossFLOW repo root
+mkdir -p your-project/.claude/skills/fossflow
+cp -r integrations/claude-code-skill/* your-project/.claude/skills/fossflow/
+```
+
+Or copy it to your global Claude Code skills:
+
+```bash
+mkdir -p ~/.claude/skills/fossflow
+cp -r integrations/claude-code-skill/* ~/.claude/skills/fossflow/
+```
+
+## Usage
+
+Once installed, use the `/fossflow` command in Claude Code:
+
+```
+/fossflow architecture diagram for my project
+/fossflow AWS infrastructure with Lambda, API Gateway and DynamoDB
+/fossflow data flow from database to frontend
+/fossflow Kubernetes deployment with ingress, services and pods
+```
+
+## Skill Structure
+
+```
+claude-code-skill/
+├── SKILL.md                        # Main skill instructions
+└── references/
+    ├── fossflow-schema.md          # Complete JSON schema (compact + full format)
+    └── icon-catalog.md             # All 1,062 icons with usage guide
+```
+
+## Output
+
+The skill generates a `.json` file importable directly into FossFLOW via **Import** in the app menu.

--- a/integrations/claude-code-skill/SKILL.md
+++ b/integrations/claude-code-skill/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: fossflow
+description: Generate isometric infrastructure and architecture diagrams in FossFLOW JSON format. This skill should be used when users want to create architecture diagrams, data flow diagrams, infrastructure visualizations, or system design diagrams that can be imported into the FossFLOW editor (https://github.com/stan-smith/FossFLOW). Triggers on requests like "create a diagram", "generate an architecture diagram", "make a FossFLOW diagram", or any /fossflow command.
+---
+
+# FossFLOW Diagram Generator
+
+## Overview
+
+Generate valid FossFLOW JSON diagrams — isometric architecture, data flow, and infrastructure visualizations. Output files are importable directly into the FossFLOW PWA editor.
+
+## Workflow
+
+### 1. Analyze the Request
+
+Determine the diagram type from the user's request:
+
+| Request Pattern | Diagram Type | Approach |
+|---|---|---|
+| "architecture diagram for this project" | **Codebase Architecture** | Read key files (entry points, router, main components) to map structure |
+| "data flow diagram" | **Data Pipeline** | Trace data from source through transformations to UI |
+| "infrastructure diagram" | **Cloud Infrastructure** | Map cloud services, networking, and connections |
+| "system design for X" | **System Design** | Design services, databases, queues, and their interactions |
+| "diagram of X" | **Custom** | Analyze what X is and create appropriate visualization |
+
+For codebase-related diagrams, read the relevant source files to understand the actual architecture before generating. Never guess structure — always verify by reading code.
+
+### 2. Choose the Format
+
+**Always prefer the Compact format** unless the user explicitly needs:
+- Custom connector labels, styles, or colors → use Full format
+- Colored rectangular regions or text boxes → use Full format
+- Fine-grained control over connector routing → use Full format
+
+### 3. Select Icons
+
+Load `references/icon-catalog.md` to select appropriate icons. Follow these guidelines:
+
+- For **generic architecture**: use ISOFLOW icons (`server`, `storage`, `cache`, `cube`, etc.)
+- For **AWS infrastructure**: use `aws-*` prefixed icons
+- For **Azure infrastructure**: use `azure-*` prefixed icons
+- For **GCP infrastructure**: use `gcp-*` prefixed icons
+- For **Kubernetes**: use `k8s-*` prefixed icons
+- **Mix collections** when the architecture spans multiple providers
+
+Icon selection priorities:
+1. Use the most specific icon available (e.g. `aws-lambda` over `function-module` for Lambda)
+2. Use `cube` or `block` as fallback for components without a clear match
+3. Use `diamond` for decision points, routers, or branching logic
+4. Use `firewall` for validation, security, or schema enforcement layers
+
+### 4. Design the Layout
+
+Plan node positions on the isometric grid before writing JSON:
+
+**Layout principles:**
+- **Flow direction**: Top-to-bottom (decreasing to increasing Y) for data pipelines, left-to-right (decreasing to increasing X) for horizontal architectures
+- **Spacing**: 3-4 units between directly connected nodes, 5+ units between parallel branches
+- **Grouping**: Place related nodes close together (e.g. API + Database, Frontend components)
+- **Symmetry**: Center the main pipeline, branch secondary items left/right
+- **Grid range**: Stay within -15 to +15 on both axes for readability
+
+**Common layout patterns:**
+
+```
+Linear Pipeline (vertical):
+  [Source]     (0, -8)
+     |
+  [Process]    (0, -4)
+     |
+  [Output]     (0, 0)
+
+Branching (fan-out):
+              [Source]           (0, -4)
+            /    |    \
+  [Branch A] [Branch B] [Branch C]
+  (-6, 0)    (0, 0)     (6, 0)
+
+Bidirectional (feedback loops):
+  [UI] ←→ [State] ←→ [API]
+  (-6, 0)  (0, 0)    (6, 0)
+```
+
+### 5. Generate the JSON
+
+Load `references/fossflow-schema.md` for the complete schema reference.
+
+**Compact format template:**
+
+```json
+{
+  "t": "Title (max 40 chars)",
+  "i": [
+    ["Node Name", "icon_id", "Short description"]
+  ],
+  "v": [
+    [
+      [[itemIndex, x, y]],
+      [[fromIndex, toIndex]]
+    ]
+  ],
+  "_": { "f": "compact", "v": "1.0" }
+}
+```
+
+**Generation rules:**
+- Every item in `i` must appear exactly once in the positions array
+- Connection indices are zero-based references into the `i` array
+- Connections represent data flow direction (from → to)
+- Avoid crossing connections where possible by adjusting positions
+- Keep descriptions concise — they appear as tooltips in the editor
+
+### 6. Write and Explain
+
+1. Write the JSON file using the Write tool (default filename: `architecture-diagram.json` or a descriptive name)
+2. Provide a clear explanation of the diagram with:
+   - A summary of what the diagram shows
+   - Description of each layer/group of nodes
+   - Explanation of the data flow through connections
+   - Any feedback loops or bidirectional relationships
+
+## Diagram Quality Checklist
+
+Before writing the final file, verify:
+
+- [ ] All items have valid icon IDs from the catalog
+- [ ] All items appear in the positions array
+- [ ] All connection indices are within bounds of the items array
+- [ ] No duplicate positions (two items at the same tile)
+- [ ] Spacing between connected nodes is 3-4 units
+- [ ] Title is under 40 characters
+- [ ] Item names are under 30 characters
+- [ ] Descriptions are under 100 characters
+- [ ] The layout reads naturally in the flow direction
+
+## Examples
+
+### Web Application Architecture
+
+```json
+{
+  "t": "Web App Architecture",
+  "i": [
+    ["Browser", "desktop", "Client-side SPA"],
+    ["CDN", "sphere", "Static asset delivery"],
+    ["API Gateway", "diamond", "Request routing and auth"],
+    ["Auth Service", "lock", "JWT token validation"],
+    ["App Server", "server", "Business logic"],
+    ["Cache", "cache", "Redis session store"],
+    ["Database", "storage", "PostgreSQL primary"],
+    ["Queue", "queue", "Async job processing"],
+    ["Worker", "function-module", "Background tasks"]
+  ],
+  "v": [
+    [
+      [[0, -8, -4], [1, -4, -8], [2, 0, 0], [3, -6, 2], [4, 0, 4], [5, 6, 2], [6, 0, 8], [7, 6, 6], [8, 6, 10]],
+      [[0, 2], [1, 0], [2, 3], [2, 4], [2, 5], [4, 6], [4, 7], [7, 8], [5, 4]]
+    ]
+  ],
+  "_": { "f": "compact", "v": "1.0" }
+}
+```
+
+### Data Pipeline
+
+```json
+{
+  "t": "ETL Data Pipeline",
+  "i": [
+    ["Raw Data Lake", "storage", "S3 raw data bucket"],
+    ["Schema Validator", "firewall", "Validates incoming data format"],
+    ["Transform", "function-module", "Clean + normalize records"],
+    ["Enrichment", "package-module", "Add derived fields"],
+    ["Data Warehouse", "storage", "Analytics-ready tables"],
+    ["Dashboard", "desktop", "BI reporting interface"],
+    ["Alert System", "mail", "Anomaly notifications"]
+  ],
+  "v": [
+    [
+      [[0, 0, -10], [1, 0, -6], [2, 0, -2], [3, 0, 2], [4, 0, 6], [5, -5, 10], [6, 5, 10]],
+      [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5], [4, 6]]
+    ]
+  ],
+  "_": { "f": "compact", "v": "1.0" }
+}
+```
+
+## Resources
+
+- `references/fossflow-schema.md` — Complete JSON schema for both compact and full formats
+- `references/icon-catalog.md` — All 1,062 available icons across 5 collections (ISOFLOW, AWS, Azure, GCP, K8s)

--- a/integrations/claude-code-skill/references/fossflow-schema.md
+++ b/integrations/claude-code-skill/references/fossflow-schema.md
@@ -1,0 +1,273 @@
+# FossFLOW Diagram JSON Schema Reference
+
+FossFLOW supports two JSON formats: **Compact** (optimized for LLM generation) and **Full** (native editor format).
+
+## Compact Format (Preferred for Generation)
+
+Token-efficient format designed for AI generation. FossFLOW auto-expands it on import.
+
+```json
+{
+  "t": "Diagram Title (max 40 chars)",
+  "i": [
+    ["Item Name (max 30)", "icon_id", "Description (max 100)"]
+  ],
+  "v": [
+    [
+      [[itemIndex, x, y], [itemIndex, x, y]],
+      [[fromIndex, toIndex], [fromIndex, toIndex]]
+    ]
+  ],
+  "_": { "f": "compact", "v": "1.0" }
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `t` | string | Diagram title, max 40 characters |
+| `i` | array | Items array. Each item: `[name, icon_id, description]` |
+| `v` | array | Views array. Each view: `[positions, connections]` |
+| `_` | object | Metadata marker, always `{"f": "compact", "v": "1.0"}` |
+
+### Items (`i`)
+
+Each item is a 3-element array:
+- `[0]` name: Display label (max 30 chars)
+- `[1]` icon_id: Icon identifier from the catalog (e.g. `"server"`, `"aws-ec2"`)
+- `[2]` description: Tooltip/description text (max 100 chars)
+
+### Views (`v`)
+
+Each view is a 2-element array: `[positions, connections]`
+
+**Positions**: `[itemIndex, x, y]`
+- `itemIndex`: Zero-based index into the items (`i`) array
+- `x`: Grid x-coordinate (integer, negative = left, positive = right)
+- `y`: Grid y-coordinate (integer, negative = up, positive = down)
+
+**Connections**: `[fromIndex, toIndex]`
+- `fromIndex`: Index of source item in items array
+- `toIndex`: Index of target item in items array
+
+### Position System
+
+- Isometric grid with integer-based coordinates
+- Each unit = one tile (~141.5 x 81.9 pixels projected)
+- Typical range: -20 to +20 for both axes
+- Recommended spacing: 3-5 units between connected nodes
+- For readability, keep 4+ units between unconnected nodes
+
+### Compact Format Example
+
+```json
+{
+  "t": "AWS Serverless Architecture",
+  "i": [
+    ["CloudFront", "aws-cloudfront", "CDN and content delivery"],
+    ["API Gateway", "aws-api-gateway", "REST API management"],
+    ["Lambda", "aws-lambda", "Serverless compute functions"],
+    ["DynamoDB", "aws-dynamodb", "NoSQL database"],
+    ["S3 Bucket", "aws-s3", "Static file storage"]
+  ],
+  "v": [
+    [
+      [[0, -8, -4], [1, 0, 0], [2, 0, 4], [3, 8, 4], [4, 8, -4]],
+      [[0, 1], [1, 2], [2, 3], [0, 4]]
+    ]
+  ],
+  "_": { "f": "compact", "v": "1.0" }
+}
+```
+
+---
+
+## Full Format
+
+Native editor format with UUIDs, colors, connectors with labels, rectangles, and text boxes.
+
+### Top-Level Structure
+
+```json
+{
+  "version": "1.0.0",
+  "title": "string (max 100)",
+  "description": "string (max 1000)",
+  "icons": [],
+  "colors": [],
+  "items": [],
+  "views": [],
+  "fitToView": true
+}
+```
+
+### Icons
+
+```json
+{
+  "id": "server",
+  "name": "Server",
+  "url": "data:image/svg+xml;base64,...",
+  "collection": "ISOFLOW",
+  "isIsometric": true,
+  "scale": 1.0
+}
+```
+
+### Colors
+
+```json
+{
+  "id": "blue",
+  "value": "#0066cc"
+}
+```
+
+### Model Items (Node Catalog)
+
+```json
+{
+  "id": "uuid-string",
+  "name": "Item Name (max 100)",
+  "description": "Rich text (max 1000)",
+  "icon": "icon-id-reference"
+}
+```
+
+### Views
+
+```json
+{
+  "id": "uuid",
+  "name": "View Name (max 100)",
+  "description": "max 1000",
+  "items": [],
+  "connectors": [],
+  "rectangles": [],
+  "textBoxes": []
+}
+```
+
+### View Items (Placement)
+
+```json
+{
+  "id": "references-a-model-item-id",
+  "tile": { "x": 0, "y": 0 },
+  "labelHeight": 80
+}
+```
+
+### Connectors
+
+```json
+{
+  "id": "uuid",
+  "color": "color-id-reference",
+  "customColor": "#rgb",
+  "width": 10,
+  "style": "SOLID | DOTTED | DASHED",
+  "lineType": "SINGLE | DOUBLE | DOUBLE_WITH_CIRCLE",
+  "showArrow": true,
+  "anchors": [
+    { "id": "uuid", "ref": { "item": "view-item-id" } },
+    { "id": "uuid", "ref": { "item": "view-item-id" } }
+  ],
+  "labels": [
+    { "id": "uuid", "text": "Label text", "position": 50, "height": 0 }
+  ]
+}
+```
+
+Anchor `ref` supports exactly one of:
+- `{ "item": "view-item-id" }` — snaps to an item
+- `{ "anchor": "anchor-id" }` — references another anchor
+- `{ "tile": { "x": 0, "y": 0 } }` — fixed grid position
+
+### Rectangles (Colored Regions)
+
+```json
+{
+  "id": "uuid",
+  "color": "color-id",
+  "customColor": "#rgb",
+  "from": { "x": 0, "y": 0 },
+  "to": { "x": 5, "y": 3 }
+}
+```
+
+### Text Boxes
+
+```json
+{
+  "id": "uuid",
+  "tile": { "x": 0, "y": 0 },
+  "content": "Label text (max 100)",
+  "fontSize": 0.6,
+  "orientation": "X | Y"
+}
+```
+
+### Full Format Example
+
+```json
+{
+  "title": "Simple Architecture",
+  "icons": [
+    { "id": "server", "name": "server", "url": "data:image/svg+xml;base64,...", "isIsometric": true }
+  ],
+  "colors": [
+    { "id": "blue", "value": "#0066cc" }
+  ],
+  "items": [
+    { "id": "item-1", "name": "Web Server", "icon": "server" },
+    { "id": "item-2", "name": "Database", "icon": "storage" }
+  ],
+  "views": [
+    {
+      "id": "view-1",
+      "name": "Overview",
+      "items": [
+        { "id": "item-1", "tile": { "x": 0, "y": 0 }, "labelHeight": 80 },
+        { "id": "item-2", "tile": { "x": 4, "y": 4 }, "labelHeight": 80 }
+      ],
+      "connectors": [
+        {
+          "id": "conn-1",
+          "color": "blue",
+          "anchors": [
+            { "id": "a1", "ref": { "item": "item-1" } },
+            { "id": "a2", "ref": { "item": "item-2" } }
+          ]
+        }
+      ],
+      "rectangles": [],
+      "textBoxes": []
+    }
+  ],
+  "fitToView": true
+}
+```
+
+### Validation Rules
+
+1. Every `ViewItem.id` must reference an existing `ModelItem.id`
+2. Every `ModelItem.icon` must reference an existing `Icon.id`
+3. Every `Connector.color` must reference an existing `Color.id`
+4. Every `Rectangle.color` must reference an existing `Color.id`
+5. `ConnectorAnchor.ref.item` must reference a `ViewItem.id` in the same view
+6. Each anchor `ref` must have exactly one key (`item`, `anchor`, or `tile`)
+7. Each connector must have at least 2 anchors
+
+### Default Values
+
+| Property | Default |
+|---|---|
+| `Connector.width` | `10` |
+| `Connector.style` | `'SOLID'` |
+| `Connector.lineType` | `'SINGLE'` |
+| `Connector.showArrow` | `true` |
+| `ViewItem.labelHeight` | `80` |
+| `TextBox.orientation` | `'X'` |
+| `TextBox.fontSize` | `0.6` |

--- a/integrations/claude-code-skill/references/icon-catalog.md
+++ b/integrations/claude-code-skill/references/icon-catalog.md
@@ -1,0 +1,163 @@
+# FossFLOW Icon Catalog
+
+1,062 total icons across 5 collections. Use the `id` value when referencing icons in diagrams.
+
+## ISOFLOW Collection (37 icons)
+
+General-purpose isometric icons. Best for generic architecture diagrams.
+
+| ID | Name | Best For |
+|----|------|----------|
+| `block` | Block | Generic component, module |
+| `cache` | Cache | Caching layer, Redis, Memcached |
+| `cardterminal` | Card Terminal | Payment processing |
+| `cloud` | Cloud | Cloud service, external API, SaaS |
+| `cronjob` | Cron Job | Scheduled tasks, background jobs |
+| `cube` | Cube | Generic service, application |
+| `desktop` | Desktop | Client, browser, workstation |
+| `diamond` | Diamond | Decision point, router, gateway |
+| `dns` | DNS | DNS, domain resolution, search |
+| `document` | Document | File, document, config |
+| `firewall` | Firewall | Security, WAF, validation |
+| `function-module` | Function Module | Function, Lambda, serverless |
+| `image` | Image | Media, image processing |
+| `laptop` | Laptop | Client device, developer |
+| `loadbalancer` | Load Balancer | Load balancing, traffic distribution |
+| `lock` | Lock | Authentication, encryption, security |
+| `mail` | Mail | Email, notifications |
+| `mailmultiple` | Mail Multiple | Batch email, message queue |
+| `mobiledevice` | Mobile Device | Mobile app, responsive |
+| `office` | Office | Organization, company |
+| `package-module` | Package Module | Package, library, dependency |
+| `paymentcard` | Payment Card | Payment, billing |
+| `plane` | Plane | Deployment, delivery |
+| `printer` | Printer | Output, reporting |
+| `pyramid` | Pyramid | Hierarchy, aggregation |
+| `queue` | Queue | Message queue, SQS, RabbitMQ |
+| `router` | Router | Network router, API router |
+| `server` | Server | Server, backend, API |
+| `speech` | Speech | Chat, communication, webhook |
+| `sphere` | Sphere | Global, CDN, distribution |
+| `storage` | Storage | Database, storage, S3 |
+| `switch-module` | Switch Module | Switch, toggle, feature flag |
+| `tower` | Tower | Infrastructure, broadcast |
+| `truck` | Truck | CI/CD, delivery pipeline |
+| `truck-2` | Truck 2 | Alternative delivery icon |
+| `user` | User | User, person, identity |
+| `vm` | VM | Virtual machine, container |
+
+## AWS Collection (320 icons)
+
+Prefix: `aws-`. Common icons:
+
+| ID | Best For |
+|----|----------|
+| `aws-ec2` | EC2 instances |
+| `aws-simple-storage-service` | S3 storage |
+| `aws-lambda` | Lambda functions |
+| `aws-rds` | RDS databases |
+| `aws-dynamodb` | DynamoDB |
+| `aws-api-gateway` | API Gateway |
+| `aws-cloudfront` | CloudFront CDN |
+| `aws-simple-queue-service` | SQS queues |
+| `aws-simple-notification-service` | SNS notifications |
+| `aws-elastic-container-service` | ECS containers |
+| `aws-elastic-kubernetes-service` | EKS Kubernetes |
+| `aws-elasticache` | ElastiCache |
+| `aws-route-53` | Route 53 DNS |
+| `aws-cognito` | Cognito auth |
+| `aws-identity-and-access-management` | IAM permissions |
+| `aws-cloudwatch` | CloudWatch monitoring |
+| `aws-kinesis` | Kinesis streaming |
+| `aws-step-functions` | Step Functions |
+| `aws-secrets-manager` | Secrets Manager |
+| `aws-elastic-load-balancing` | Elastic Load Balancer |
+| `aws-fargate` | Fargate serverless containers |
+| `aws-aurora` | Aurora database |
+| `aws-redshift` | Redshift data warehouse |
+| `aws-athena` | Athena queries |
+
+## Azure Collection (369 icons)
+
+Prefix: `azure-`. Common icons:
+
+| ID | Best For |
+|----|----------|
+| `azure-virtual-machine` | Virtual Machines |
+| `azure-sql-database` | SQL Database |
+| `azure-app-services` | App Services |
+| `azure-function-apps` | Azure Functions |
+| `azure-blob-block` | Blob Storage |
+| `azure-cosmos-db` | Cosmos DB |
+| `azure-active-directory` | Active Directory |
+| `azure-api-management-services` | API Management |
+| `azure-kubernetes-services` | AKS |
+| `azure-cache-redis` | Redis Cache |
+| `azure-cdn-profiles` | Azure CDN |
+| `azure-event-hubs` | Event Hubs |
+| `azure-service-bus` | Service Bus |
+| `azure-key-vaults` | Key Vault |
+| `azure-monitor` | Azure Monitor |
+| `azure-load-balancers` | Load Balancer |
+| `azure-front-doors` | Front Door |
+| `azure-container-instances` | Container Instances |
+
+## GCP Collection (280 icons)
+
+Prefix: `gcp-`. Common icons:
+
+| ID | Best For |
+|----|----------|
+| `gcp-compute-engine` | Compute Engine |
+| `gcp-cloud-storage` | Cloud Storage |
+| `gcp-cloud-sql` | Cloud SQL |
+| `gcp-cloud-functions` | Cloud Functions |
+| `gcp-cloud-run` | Cloud Run |
+| `gcp-bigquery` | BigQuery |
+| `gcp-pubsub` | Pub/Sub |
+| `gcp-cloud-cdn` | Cloud CDN |
+| `gcp-cloud-load-balancing` | Load Balancing |
+| `gcp-cloud-armor` | Cloud Armor |
+| `gcp-cloud-dns` | Cloud DNS |
+| `gcp-firestore` | Firestore |
+| `gcp-memorystore` | Memorystore |
+| `gcp-google-kubernetes-engine` | GKE |
+| `gcp-cloud-tasks` | Cloud Tasks |
+| `gcp-identity-platform` | Identity Platform |
+
+## Kubernetes Collection (56 icons)
+
+Prefix: `k8s-`. Common icons:
+
+| ID | Best For |
+|----|----------|
+| `k8s-pod` | Pod |
+| `k8s-svc` | Service |
+| `k8s-deploy` | Deployment |
+| `k8s-ing` | Ingress |
+| `k8s-ns` | Namespace |
+| `k8s-cm` | ConfigMap |
+| `k8s-secret` | Secret |
+| `k8s-pv` | Persistent Volume |
+| `k8s-pvc` | Persistent Volume Claim |
+| `k8s-ds` | DaemonSet |
+| `k8s-sts` | StatefulSet |
+| `k8s-job` | Job |
+| `k8s-cronjob` | CronJob |
+| `k8s-hpa` | Horizontal Pod Autoscaler |
+| `k8s-sa` | Service Account |
+| `k8s-role` | Role |
+
+## Icon Selection Guide
+
+| Diagram Type | Recommended Icons |
+|---|---|
+| **Web App Architecture** | `desktop`, `server`, `storage`, `cache`, `cloud`, `cube` |
+| **Data Pipeline** | `storage`, `queue`, `function-module`, `diamond`, `document` |
+| **Microservices** | `cube`, `server`, `loadbalancer`, `queue`, `cache`, `storage` |
+| **CI/CD Pipeline** | `truck`, `package-module`, `server`, `cloud`, `firewall` |
+| **Auth/Security** | `lock`, `firewall`, `user`, `cloud`, `server` |
+| **AWS Architecture** | Use `aws-*` prefixed icons |
+| **Azure Architecture** | Use `azure-*` prefixed icons |
+| **GCP Architecture** | Use `gcp-*` prefixed icons |
+| **Kubernetes** | Use `k8s-*` prefixed icons |


### PR DESCRIPTION
## What does this PR do?

The `LLM-GENERATION-GUIDE.md` contains ~40 icon IDs that don't match the actual icon names from the `@isoflow/isopacks` library (as documented in `icon-list-generation-guide.md`). This causes LLM-generated diagrams to reference non-existent icons, breaking import.

This PR cross-references every icon ID against `icon-list-generation-guide.md` and fixes all mismatches. It also adds a Claude Code skill for generating FossFLOW diagrams via LLM.

Fixes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [x] Documentation update

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have tested these changes locally and they work
- [x] I can explain every line of code in this PR if asked
- [x] This PR does not contain AI-generated code that I haven't personally reviewed, understood, and tested
- [x] I have not added any unnecessary comments, logging, or dead code
- [x] My code follows the existing style and conventions of the project
- [x] I have updated documentation if applicable

## How to test

1. Open the updated `LLM-GENERATION-GUIDE.md` and pick any icon ID listed
2. Search for that exact ID in `icon-list-generation-guide.md` — it should match
3. Import any of the 3 JSON examples into FossFLOW — icons should render correctly

## Changes summary

**ISOFLOW section** — Replaced 11 non-existent IDs (`network`, `security`, `api`, `function`, `mobile`, `web`, `email`, `analytics`, `backup`, `load-balancer`, `cdn`, `vpn`, `monitor`) with actual IDs (`router`, `firewall`, `function-module`, `mobiledevice`, `desktop`, `mail`, `loadbalancer`, `sphere`, etc.). Listed all 36 of 37 available icons with usage descriptions.

**AWS section** — Fixed 7 shorthand IDs: `aws-s3` → `aws-simple-storage-service`, `aws-sqs` → `aws-simple-queue-service`, `aws-sns` → `aws-simple-notification-service`, `aws-elb` → `aws-elastic-load-balancing`, `aws-iam` → `aws-identity-and-access-management`, `aws-eks` → `aws-elastic-kubernetes-service`, `aws-elasticsearch` → `aws-opensearch-service`. Removed non-existent `aws-vpc`.

**Azure section** — Fixed 9 IDs to match actual pluralized/suffixed names (`azure-app-service` → `azure-app-services`, `azure-redis-cache` → `azure-cache-redis`, `azure-cdn` → `azure-cdn-profiles`, etc.).

**GCP section** — Fixed 5 IDs (`gcp-cloud-pub-sub` → `gcp-pubsub`, `gcp-kubernetes-engine` → `gcp-google-kubernetes-engine`, `gcp-cloud-firestore` → `gcp-firestore`, etc.).

**K8s section** — Fixed 8 IDs from long-form to actual abbreviated format (`k8s-service` → `k8s-svc`, `k8s-deployment` → `k8s-deploy`, `k8s-configmap` → `k8s-cm`, `k8s-ingress` → `k8s-ing`, etc.).

**JSON examples** — Fixed icons in all 3 examples (`web` → `desktop`, `api` → `diamond`, `aws-s3` → `aws-simple-storage-service`, `k8s-ingress` → `k8s-ing`, etc.).

**Positioning** — Added layout pattern examples (linear pipeline, fan-out, layered architecture) and improved spacing guidelines.

**Claude Code skill** — Added `integrations/claude-code-skill/` with a ready-to-use skill for generating FossFLOW diagrams from natural language via Claude Code.