### PR TITLE
feat: enhance icon pack management with custom pack support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fossflow-monorepo",
-  "version": "1.10.4",
+  "version": "1.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fossflow-monorepo",
-      "version": "1.10.4",
+      "version": "1.10.7",
       "workspaces": [
         "packages/*"
       ],
@@ -15657,7 +15657,7 @@
       }
     },
     "packages/fossflow-app": {
-      "version": "1.10.4",
+      "version": "1.10.7",
       "dependencies": {
         "@isoflow/isopacks": "^0.0.10",
         "fossflow": "*",
@@ -15705,7 +15705,7 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "packages/fossflow-backend": {
-      "version": "1.10.4",
+      "version": "1.10.7",
       "dependencies": {
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
@@ -15718,7 +15718,7 @@
     },
     "packages/fossflow-lib": {
       "name": "fossflow",
-      "version": "1.10.4",
+      "version": "1.10.7",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/packages/fossflow-app/src/services/iconPackManager.ts
+++ b/packages/fossflow-app/src/services/iconPackManager.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { flattenCollections } from '@isoflow/isopacks/dist/utils';
 
 // Available icon packs (excluding core isoflow which is always loaded)
-export type IconPackName = 'aws' | 'gcp' | 'azure' | 'kubernetes';
+export type IconPackName = string;
 
 export interface IconPackInfo {
   name: IconPackName;
@@ -24,8 +24,8 @@ export interface IconPackManagerState {
 const LAZY_LOADING_KEY = 'fossflow-lazy-loading-enabled';
 const ENABLED_PACKS_KEY = 'fossflow-enabled-icon-packs';
 
-// Pack metadata
-const PACK_METADATA: Record<IconPackName, string> = {
+// Pack metadata for known packs. Custom packs will be stored in localStorage.
+const PACK_METADATA: Record<string, string> = {
   aws: 'AWS Icons',
   gcp: 'Google Cloud Icons',
   azure: 'Azure Icons',
@@ -58,6 +58,7 @@ export const saveEnabledPacks = (packs: IconPackName[]): void => {
 
 // Dynamic pack loader
 export const loadIconPack = async (packName: IconPackName): Promise<any> => {
+  // Try known dynamic imports first
   switch (packName) {
     case 'aws':
       return (await import('@isoflow/isopacks/dist/aws')).default;
@@ -68,8 +69,38 @@ export const loadIconPack = async (packName: IconPackName): Promise<any> => {
     case 'kubernetes':
       return (await import('@isoflow/isopacks/dist/kubernetes')).default;
     default:
-      throw new Error(`Unknown icon pack: ${packName}`);
+      // Unknown packName — custom packs are expected to be stored and resolved by the manager
+      throw new Error(`Unknown icon pack for dynamic import: ${packName}`);
   }
+};
+
+// Custom packs storage key
+const CUSTOM_PACKS_KEY = 'fossflow-custom-icon-packs';
+
+export interface StoredCustomPack {
+  name: string;
+  displayName: string;
+  icons: any[]; // flattened icons array
+}
+
+export const loadCustomPacksFromStorage = (): Record<
+  string,
+  StoredCustomPack
+> => {
+  const s = localStorage.getItem(CUSTOM_PACKS_KEY);
+  if (!s) return {};
+  try {
+    return JSON.parse(s) as Record<string, StoredCustomPack>;
+  } catch (e) {
+    console.error('Failed to parse custom icon packs from storage', e);
+    return {};
+  }
+};
+
+export const saveCustomPacksToStorage = (
+  packs: Record<string, StoredCustomPack>
+) => {
+  localStorage.setItem(CUSTOM_PACKS_KEY, JSON.stringify(packs));
 };
 
 // React hook for managing icon packs
@@ -82,105 +113,171 @@ export const useIconPackManager = (coreIcons: any[]) => {
     loadEnabledPacks()
   );
 
-  const [packInfo, setPackInfo] = useState<Record<IconPackName, IconPackInfo>>(() => {
-    const info: Record<string, IconPackInfo> = {};
-    const packNames: IconPackName[] = ['aws', 'gcp', 'azure', 'kubernetes'];
-    packNames.forEach(name => {
-      info[name] = {
-        name,
-        displayName: PACK_METADATA[name],
-        loaded: false,
-        loading: false,
-        error: null,
-        iconCount: 0
-      };
-    });
-    return info as Record<IconPackName, IconPackInfo>;
-  });
+  // Load any custom packs from storage and initialize packInfo
+  const storedCustomPacks = loadCustomPacksFromStorage();
+
+  const [packInfo, setPackInfo] = useState<Record<IconPackName, IconPackInfo>>(
+    () => {
+      const info: Record<string, IconPackInfo> = {};
+      const defaultPackNames: IconPackName[] = [
+        'aws',
+        'gcp',
+        'azure',
+        'kubernetes'
+      ];
+      const packNames = [
+        ...defaultPackNames,
+        ...Object.keys(storedCustomPacks)
+      ];
+      packNames.forEach((name) => {
+        info[name] = {
+          name,
+          displayName:
+            storedCustomPacks[name]?.displayName || PACK_METADATA[name] || name,
+          loaded: false,
+          loading: false,
+          error: null,
+          iconCount: 0
+        };
+      });
+      return info as Record<IconPackName, IconPackInfo>;
+    }
+  );
 
   const [loadedIcons, setLoadedIcons] = useState<any[]>(coreIcons);
-  const [loadedPackData, setLoadedPackData] = useState<Record<IconPackName, any>>({} as Record<IconPackName, any>);
+  const [loadedPackData, setLoadedPackData] = useState<
+    Record<IconPackName, any>
+  >({} as Record<IconPackName, any>);
 
   // Load a specific pack
-  const loadPack = useCallback(async (packName: IconPackName) => {
-    // Already loaded?
-    if (packInfo[packName].loaded || packInfo[packName].loading) {
-      return;
-    }
+  const loadPack = useCallback(
+    async (packName: IconPackName) => {
+      // Already loaded?
+      if (packInfo[packName]?.loaded || packInfo[packName]?.loading) {
+        return;
+      }
 
-    // Set loading state
-    setPackInfo(prev => ({
-      ...prev,
-      [packName]: { ...prev[packName], loading: true, error: null }
-    }));
-
-    try {
-      const pack = await loadIconPack(packName);
-      const flattenedIcons = flattenCollections([pack]);
-
-      // Store the loaded pack data
-      setLoadedPackData(prev => ({
+      // Set loading state
+      setPackInfo((prev) => ({
         ...prev,
-        [packName]: pack
+        [packName]: { ...prev[packName], loading: true, error: null }
       }));
 
-      // Update pack info
-      setPackInfo(prev => ({
-        ...prev,
-        [packName]: {
-          ...prev[packName],
-          loaded: true,
-          loading: false,
-          iconCount: flattenedIcons.length,
-          error: null
+      try {
+        // First check if we already have the pack data cached (including custom packs)
+        let pack: any = loadedPackData[packName];
+
+        // If not cached, check stored custom packs
+        if (!pack) {
+          const stored = loadCustomPacksFromStorage();
+          if (stored[packName]) {
+            pack = { __custom: true, icons: stored[packName].icons };
+          }
         }
-      }));
 
-      // Add icons to the loaded icons array
-      setLoadedIcons(prev => [...prev, ...flattenedIcons]);
-
-      return flattenedIcons;
-    } catch (error) {
-      console.error(`Failed to load ${packName} icon pack:`, error);
-      setPackInfo(prev => ({
-        ...prev,
-        [packName]: {
-          ...prev[packName],
-          loading: false,
-          error: error instanceof Error ? error.message : 'Failed to load pack'
+        // If still not found, try dynamic import for known packs
+        if (!pack) {
+          try {
+            pack = await loadIconPack(packName);
+          } catch (e) {
+            throw e;
+          }
         }
-      }));
-      throw error;
-    }
-  }, [packInfo]);
+
+        // Determine flattened icons
+        let flattenedIcons: any[] = [];
+        if (pack.__custom && Array.isArray(pack.icons)) {
+          flattenedIcons = pack.icons;
+        } else {
+          flattenedIcons = flattenCollections([pack]);
+        }
+
+        // Store the loaded pack data
+        setLoadedPackData((prev) => ({
+          ...prev,
+          [packName]: pack
+        }));
+
+        // Update pack info
+        setPackInfo((prev) => ({
+          ...prev,
+          [packName]: {
+            ...(prev[packName] || {
+              name: packName,
+              displayName: PACK_METADATA[packName] || packName
+            }),
+            loaded: true,
+            loading: false,
+            iconCount: flattenedIcons.length,
+            error: null
+          }
+        }));
+
+        // Add icons to the loaded icons array
+        setLoadedIcons((prev) => [...prev, ...flattenedIcons]);
+
+        return flattenedIcons;
+      } catch (error) {
+        console.error(`Failed to load ${packName} icon pack:`, error);
+        setPackInfo((prev) => ({
+          ...prev,
+          [packName]: {
+            ...(prev[packName] || {
+              name: packName,
+              displayName: PACK_METADATA[packName] || packName
+            }),
+            loading: false,
+            error:
+              error instanceof Error ? error.message : 'Failed to load pack'
+          }
+        }));
+        throw error;
+      }
+    },
+    [packInfo]
+  );
 
   // Enable/disable a pack
-  const togglePack = useCallback(async (packName: IconPackName, enabled: boolean) => {
-    if (enabled) {
-      // Add to enabled packs
-      const newEnabledPacks = [...enabledPacks, packName];
-      setEnabledPacks(newEnabledPacks);
-      saveEnabledPacks(newEnabledPacks);
+  const togglePack = useCallback(
+    async (packName: IconPackName, enabled: boolean) => {
+      if (enabled) {
+        // Add to enabled packs
+        const newEnabledPacks = [...enabledPacks, packName];
+        setEnabledPacks(newEnabledPacks);
+        saveEnabledPacks(newEnabledPacks);
 
-      // Load the pack
-      await loadPack(packName);
-    } else {
-      // Remove from enabled packs
-      const newEnabledPacks = enabledPacks.filter(p => p !== packName);
-      setEnabledPacks(newEnabledPacks);
-      saveEnabledPacks(newEnabledPacks);
+        // Load the pack
+        await loadPack(packName);
+      } else {
+        // Remove from enabled packs
+        const newEnabledPacks = enabledPacks.filter((p) => p !== packName);
+        setEnabledPacks(newEnabledPacks);
+        saveEnabledPacks(newEnabledPacks);
 
-      // Remove icons from loaded icons
-      // We need to rebuild the icons array from core + enabled packs
-      const newIcons = [coreIcons];
-      for (const pack of newEnabledPacks) {
-        if (loadedPackData[pack]) {
-          newIcons.push(flattenCollections([loadedPackData[pack]]));
+        // Remove icons from loaded icons
+        // We need to rebuild the icons array from core + enabled packs
+        const newIcons = [coreIcons];
+        for (const pack of newEnabledPacks) {
+          const data = loadedPackData[pack];
+          if (data) {
+            if (data.__custom && Array.isArray(data.icons)) {
+              newIcons.push(data.icons);
+            } else {
+              newIcons.push(flattenCollections([data]));
+            }
+          } else {
+            // If data not in cache, try to load from storage for custom packs
+            const stored = loadCustomPacksFromStorage();
+            if (stored[pack]) {
+              newIcons.push(stored[pack].icons);
+            }
+          }
         }
+        setLoadedIcons(newIcons.flat());
       }
-      setLoadedIcons(newIcons.flat());
-    }
-  }, [enabledPacks, loadPack, coreIcons, loadedPackData]);
+    },
+    [enabledPacks, loadPack, coreIcons, loadedPackData]
+  );
 
   // Toggle lazy loading
   const toggleLazyLoading = useCallback((enabled: boolean) => {
@@ -190,50 +287,65 @@ export const useIconPackManager = (coreIcons: any[]) => {
 
   // Load all packs (for when lazy loading is disabled)
   const loadAllPacks = useCallback(async () => {
-    const allPacks: IconPackName[] = ['aws', 'gcp', 'azure', 'kubernetes'];
+    const stored = loadCustomPacksFromStorage();
+    const customNames = Object.keys(stored);
+    const allPacks: IconPackName[] = [
+      'aws',
+      'gcp',
+      'azure',
+      'kubernetes',
+      ...customNames
+    ];
     for (const pack of allPacks) {
-      if (!packInfo[pack].loaded && !packInfo[pack].loading) {
+      if (!packInfo[pack]?.loaded && !packInfo[pack]?.loading) {
         await loadPack(pack);
       }
     }
   }, [packInfo, loadPack]);
 
   // Auto-detect required packs from diagram data
-  const loadPacksForDiagram = useCallback(async (diagramItems: any[]) => {
-    if (!diagramItems || diagramItems.length === 0) return;
+  const loadPacksForDiagram = useCallback(
+    async (diagramItems: any[]) => {
+      if (!diagramItems || diagramItems.length === 0) return;
 
-    // Extract unique collections from diagram items
-    const collections = new Set<string>();
-    diagramItems.forEach(item => {
-      if (item.icon?.collection) {
-        collections.add(item.icon.collection);
-      }
-    });
+      // Extract unique collections from diagram items
+      const collections = new Set<string>();
+      diagramItems.forEach((item) => {
+        if (item.icon?.collection) {
+          collections.add(item.icon.collection);
+        }
+      });
 
-    // Load any missing packs
-    const packsToLoad: IconPackName[] = [];
-    collections.forEach(collection => {
-      if (collection !== 'isoflow' && collection !== 'imported') {
-        const packName = collection as IconPackName;
-        if (['aws', 'gcp', 'azure', 'kubernetes'].includes(packName)) {
-          if (!packInfo[packName].loaded && !packInfo[packName].loading) {
-            packsToLoad.push(packName);
+      // Load any missing packs (including custom packs present in storage)
+      const packsToLoad: IconPackName[] = [];
+      const stored = loadCustomPacksFromStorage();
+      collections.forEach((collection) => {
+        if (collection !== 'isoflow' && collection !== 'imported') {
+          const packName = collection as IconPackName;
+          if (
+            ['aws', 'gcp', 'azure', 'kubernetes'].includes(packName) ||
+            stored[packName]
+          ) {
+            if (!packInfo[packName]?.loaded && !packInfo[packName]?.loading) {
+              packsToLoad.push(packName);
+            }
           }
         }
-      }
-    });
+      });
 
-    // Load required packs
-    for (const pack of packsToLoad) {
-      await loadPack(pack);
-      // Also add to enabled packs
-      if (!enabledPacks.includes(pack)) {
-        const newEnabledPacks = [...enabledPacks, pack];
-        setEnabledPacks(newEnabledPacks);
-        saveEnabledPacks(newEnabledPacks);
+      // Load required packs
+      for (const pack of packsToLoad) {
+        await loadPack(pack);
+        // Also add to enabled packs
+        if (!enabledPacks.includes(pack)) {
+          const newEnabledPacks = [...enabledPacks, pack];
+          setEnabledPacks(newEnabledPacks);
+          saveEnabledPacks(newEnabledPacks);
+        }
       }
-    }
-  }, [packInfo, enabledPacks, loadPack]);
+    },
+    [packInfo, enabledPacks, loadPack]
+  );
 
   // Initialize: Load enabled packs or all packs depending on lazy loading setting
   useEffect(() => {
@@ -253,6 +365,89 @@ export const useIconPackManager = (coreIcons: any[]) => {
     initialize();
   }, []); // Only run once on mount
 
+  // Add a custom icon pack (icons should be a flattened icons array)
+  const addCustomPack = useCallback(
+    (name: string, displayName: string, icons: any[]) => {
+      const stored = loadCustomPacksFromStorage();
+      stored[name] = { name, displayName, icons };
+      saveCustomPacksToStorage(stored);
+
+      // Update pack info and cache
+      setPackInfo((prev) => ({
+        ...prev,
+        [name]: {
+          name,
+          displayName,
+          loaded: true,
+          loading: false,
+          error: null,
+          iconCount: icons.length
+        }
+      }));
+
+      setLoadedPackData((prev) => ({
+        ...prev,
+        [name]: { __custom: true, icons }
+      }));
+
+      setLoadedIcons((prev) => [...prev, ...icons]);
+    },
+    []
+  );
+
+  const removeCustomPack = useCallback(
+    (name: string) => {
+      const stored = loadCustomPacksFromStorage();
+      if (stored[name]) {
+        delete stored[name];
+        saveCustomPacksToStorage(stored);
+      }
+
+      // Remove from enabled packs if present
+      setEnabledPacks((prev) => {
+        const next = prev.filter((p) => p !== name);
+        saveEnabledPacks(next);
+        return next;
+      });
+
+      // Remove from packInfo and cache
+      setLoadedPackData((prev) => {
+        const copy = { ...prev };
+        delete copy[name];
+        return copy;
+      });
+
+      setPackInfo((prev) => {
+        const copy = { ...prev };
+        delete copy[name];
+        return copy;
+      });
+
+      // Rebuild loadedIcons from core + remaining enabled packs
+      setLoadedIcons(() => {
+        const remaining = [coreIcons];
+        const currentEnabled = loadEnabledPacks();
+        const storedPacks = loadCustomPacksFromStorage();
+        for (const pack of currentEnabled) {
+          const data = loadedPackData[pack];
+          if (data) {
+            if (data.__custom && Array.isArray(data.icons)) {
+              remaining.push(data.icons);
+            } else {
+              try {
+                remaining.push(flattenCollections([data]));
+              } catch (_) {}
+            }
+          } else if (storedPacks[pack]) {
+            remaining.push(storedPacks[pack].icons);
+          }
+        }
+        return remaining.flat();
+      });
+    },
+    [loadedPackData]
+  );
+
   return {
     lazyLoadingEnabled,
     enabledPacks,
@@ -262,6 +457,8 @@ export const useIconPackManager = (coreIcons: any[]) => {
     toggleLazyLoading,
     loadAllPacks,
     loadPacksForDiagram,
-    isPackEnabled: (packName: IconPackName) => enabledPacks.includes(packName)
+    isPackEnabled: (packName: IconPackName) => enabledPacks.includes(packName),
+    addCustomPack,
+    removeCustomPack
   };
 };


### PR DESCRIPTION
## What does this PR do?

Adds support for user-imported custom icon packs and a simple upload UI. Users can now upload a JSON icon pack (either a top-level array of icons or an object `{ name, displayName, icons }`) from the app toolbar; the icons are persisted in `localStorage` under `fossflow-custom-icon-packs` and immediately merged into the available icons. The icon pack manager (`useIconPackManager`) was extended to recognize, persist, load and expose custom packs via `addCustomPack` / `removeCustomPack`. Also improved dynamic loading logic so custom packs are considered when loading required packs for a diagram.

Files changed (high level):
- iconPackManager.ts — add custom pack storage, loading and API.
- App.tsx — add hidden file input + toolbar button and import handler to upload custom icon pack JSON.

Fixes # (adds requested custom icon-pack upload feature — please add issue number if you want this to auto-close an issue)

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no functional change)
- [ ] Documentation update

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I have tested these changes locally and they work
- [x] I can explain every line of code in this PR if asked
- [x] This PR does not contain AI-generated code that I haven't personally reviewed, understood, and tested
- [x] I have not added any unnecessary comments, logging, or dead code
- [x] My code follows the existing style and conventions of the project
- [x] I have updated documentation if applicable

## How to test

1. Build the library package (so `import { Isoflow } from 'fossflow'` resolves) and start the app dev server:
```bash
npm run build --workspace=packages/fossflow-lib
npm run dev
```

2. Open the app in the browser (dev server log shows the Local/Network URL, e.g. `http://localhost:3002/`). In the toolbar you should see a new button "➕ Add Icon Pack".

3. Prepare a JSON icon pack file. Accepted formats:
   - Array of icon objects:
     ```json
     [ { "id": "my-icon", "collection": "my-pack", "svg": "<svg .../>" }, ... ]
     ```
   - Object with metadata:
     ```json
     { "name": "my-pack", "displayName": "My Pack", "icons": [ /* icon array */ ] }
     ```

4. Click "➕ Add Icon Pack" and upload the JSON file.

5. Verify:
   - You see an alert confirming the pack was added.
   - The uploaded icons are merged into the app icon list (try searching the icon sidebar or drag the new icon onto the canvas).
   - The custom pack is persisted in `localStorage` under key `fossflow-custom-icon-packs`. In DevTools console:
     ```js
     JSON.parse(localStorage.getItem('fossflow-custom-icon-packs'))
     ```
   - Save/export a diagram that uses imported icons and re-open it; the app should auto-load custom packs referenced by diagram items.

6. (Optional) Verify auto-detection:
   - Export a diagram using icons from a named custom collection (set `icon.collection` to your pack name), store it server-side (or locally), and load it — the manager should auto-load the custom pack if stored in `localStorage` or load enabled packs accordingly.

## Notes / Limitations

- The current UI only provides upload (add) functionality. Removal of custom packs is implemented in the manager API (`removeCustomPack`) but is not exposed in the toolbar UI. If you want a full management UI (list, enable/disable, remove), I can add a small panel in a follow-up.
- Custom pack files must contain a flattened icons array. The manager expects each icon object to contain the necessary properties the renderer expects (e.g., `id`, `collection`, svg/paths). Imported pack items will be added directly to the `loadedIcons` array.
- This PR stores custom packs in `localStorage`; if you want server-side persistence we can add storageService hooks to save/restore those packs.

## Screenshots (if UI change)
<img width="2507" height="1306" alt="Screenshot 2026-02-21 211142" src="https://github.com/user-attachments/assets/ff972259-cbf8-40b7-b47f-5684311f5a54" />
