### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -41,7 +41,7 @@ jobs:
             type=sha,prefix={{branch}}-,enable=${{ github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
       - name: Build
         uses: docker://node:22-alpine
         with:
@@ -42,7 +42,7 @@ jobs:
           CI: false
           PUBLIC_URL: /FossFLOW/
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           # Upload from the app's build directory in monorepo
           path: './packages/fossflow-app/build/'


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/configure-pages` | [`v4`](https://github.com/actions/configure-pages/releases/tag/v4) | [`v5`](https://github.com/actions/configure-pages/releases/tag/v5) | [Release](https://github.com/actions/configure-pages/releases/tag/v5) | pages.yml |
| `actions/upload-pages-artifact` | [`v3`](https://github.com/actions/upload-pages-artifact/releases/tag/v3) | [`v4`](https://github.com/actions/upload-pages-artifact/releases/tag/v4) | [Release](https://github.com/actions/upload-pages-artifact/releases/tag/v4) | pages.yml |
| `docker/build-push-action` | [`v5`](https://github.com/docker/build-push-action/releases/tag/v5) | [`v6`](https://github.com/docker/build-push-action/releases/tag/v6) | [Release](https://github.com/docker/build-push-action/releases/tag/v6) | docker.yml |
| `docker/setup-qemu-action` | [`v2`](https://github.com/docker/setup-qemu-action/releases/tag/v2) | [`v3`](https://github.com/docker/setup-qemu-action/releases/tag/v3) | [Release](https://github.com/docker/setup-qemu-action/releases/tag/v3) | docker.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### ⚠️ Breaking Changes

- **actions/configure-pages** (v4 → v5): Major version upgrade — review the [release notes](https://github.com/actions/configure-pages/releases) for breaking changes
- **actions/upload-pages-artifact** (v3 → v4): Major version upgrade — review the [release notes](https://github.com/actions/upload-pages-artifact/releases) for breaking changes
- **docker/setup-qemu-action** (v2 → v3): Major version upgrade — review the [release notes](https://github.com/docker/setup-qemu-action/releases) for breaking changes
- **docker/build-push-action** (v5 → v6): Major version upgrade — review the [release notes](https://github.com/docker/build-push-action/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
