### PR TITLE
fix(ui): make settings tabs scrollable to prevent hiding

### DIFF
--- a/packages/fossflow-lib/src/components/SettingsDialog/SettingsDialog.tsx
+++ b/packages/fossflow-lib/src/components/SettingsDialog/SettingsDialog.tsx
@@ -81,7 +81,7 @@ export const SettingsDialog = ({ iconPackManager }: SettingsDialogProps) => {
           onChange={handleTabChange}
           variant="scrollable"
           scrollButtons="auto"
-          allowScrollButtonsMobile  
+          allowScrollButtonsMobile
           sx={{ borderBottom: 1, borderColor: 'divider' }}
         >
           <Tab label={t('settings.hotkeys.title')} />


### PR DESCRIPTION
## What does this PR do?

this PR fixes a visual bug within the SettingsDialog.tsx component that caused the ‘Icon PackManagement’ tab to disappear from the interface when the application switched to languages with longer texts than English. this occurred specifically with spanish, russian, french, and portuguese. as reported by user <bast69> 

i initially suspected that some configuration was missing in the localization files (i18n), but I verified that the icon packs existed and were correctly translated. The real problem was that the translator generated longer strings and the total width of the tabs exceeded the maximum width of the dialog box, causing <Tabs> to hide them, as there was no container in which to display them.

this was solved by adding the properties (variant=“scrollable”), (scrollButtons=“auto”), and (allowScrollButtonsMobile) to the user interface component to prevent hidden overflow.

Fixes #228 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have tested these changes locally and they work
- [x] I can explain every line of code in this PR if asked
- [x] This PR does not contain AI-generated code that I haven't personally reviewed, understood, and tested
- [x] I have not added any unnecessary comments, logging, or dead code
- [x] My code follows the existing style and conventions of the project
- [ ] I have updated documentation if applicable

## How to test

<!-- Steps for the maintainer to verify this works: -->

1. build the library locally (npm run build:lib) and start the PWA (npm run dev).

2. open the left menu option (hamburger): settings

3. change the environment language to spanish, russian, french, or portuguese.

## Screenshots (if UI change)

<!-- Drag and drop before/after screenshots here -->

before

<img width="1917" height="915" alt="antes" src="https://github.com/user-attachments/assets/c1d86859-3192-4b8e-9808-8ab466f38b2f" />

after

<img width="1920" height="913" alt="{6458EF36-8DFA-450B-9CC4-4C7D1934A244}" src="https://github.com/user-attachments/assets/e62fee9a-f4ba-4c52-9a98-1d41a505099c" />

