### PR TITLE
fix: remove icon position glitching when placing icon

### DIFF
--- a/packages/fossflow-lib/src/components/SceneLayers/Nodes/Node/IconTypes/IsometricIcon.tsx
+++ b/packages/fossflow-lib/src/components/SceneLayers/Nodes/Node/IconTypes/IsometricIcon.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export const IsometricIcon = ({ url, scale = 1, onImageLoaded }: Props) => {
   const ref = useRef<HTMLImageElement>(null);
-  const { size, observe, disconnect } = useResizeObserver();
+  const { observe, disconnect } = useResizeObserver();
 
   useEffect(() => {
     if (!ref.current) return;
@@ -30,8 +30,6 @@ export const IsometricIcon = ({ url, scale = 1, onImageLoaded }: Props) => {
       sx={{
         position: 'absolute',
         width: PROJECTED_TILE_SIZE.width * 0.8 * scale,
-        top: -size.height,
-        left: -size.width / 2,
         pointerEvents: 'none'
       }}
     />

--- a/packages/fossflow-lib/src/components/SceneLayers/Nodes/Node/Node.tsx
+++ b/packages/fossflow-lib/src/components/SceneLayers/Nodes/Node/Node.tsx
@@ -52,17 +52,17 @@ export const Node = memo(({ node, order }: Props) => {
       }}
     >
       <Box
-        sx={{ position: 'absolute' }}
-        style={{
+        sx={{ 
+          position: 'absolute',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
           left: position.x,
-          top: position.y
+          top: position.y - (PROJECTED_TILE_SIZE.height / 2),
         }}
       >
         {(modelItem?.name || description) && (
-          <Box
-            sx={{ position: 'absolute' }}
-            style={{ bottom: PROJECTED_TILE_SIZE.height / 2 }}
-          >
+          <Box>
             <ExpandableLabel
               maxWidth={250}
               expandDirection="BOTTOM"
@@ -83,8 +83,10 @@ export const Node = memo(({ node, order }: Props) => {
         {iconComponent && (
           <Box
             sx={{
-              position: 'absolute',
-              pointerEvents: 'none'
+              pointerEvents: 'none',
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center'
             }}
           >
             {iconComponent}


### PR DESCRIPTION
## What does this PR do?
When placing a new icon, the position seems to glitch at the beginning. This PR removes that position shifting glitch. The changes done for this also seem to have fixed the jittering of icons when changing their size

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have tested these changes locally and they work
- [x] I can explain every line of code in this PR if asked
- [x] This PR does not contain AI-generated code that I haven't personally reviewed, understood, and tested
- [x] I have not added any unnecessary comments, logging, or dead code
- [x] My code follows the existing style and conventions of the project
- [x] I have updated documentation if applicable

## How to test

<!-- Steps for the maintainer to verify this works: -->

### Placing new icon
1. Click on any empty tile
2. Click on 'Add Node' on the context menu
3. Notice the icon position shift at the beginning

### Changing icon size
1. Click on any node
2. Decrease/increase icon size

## Screenshots (if UI change)
[placing icon- before](https://github.com/user-attachments/assets/92f47c13-63c2-4df4-9e2d-c3850751f701)
[placing icon - after](https://github.com/user-attachments/assets/de996061-7b08-4386-a91d-86552ff8781c)
[changing size - before](https://github.com/user-attachments/assets/fa249a96-65ce-4905-b252-124c90a8b886)
[changing size - after](https://github.com/user-attachments/assets/d7ab8e57-0091-4762-a758-1a0bf0912420)




