### PR TITLE
fflow: fix bcrypt password generation in docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN npm run build:lib && npm run build:app
 FROM node:22-alpine
 
 # Install web server packages
-RUN apk add --no-cache nginx openssl
+RUN apk add --no-cache nginx openssl apache2-utils
 
 # Copy backend code
 COPY --from=build /app/packages/fossflow-backend /app/packages/fossflow-backend

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,7 +17,7 @@ fi
 touch /etc/nginx/.htpasswd
 if [ -n "$HTTP_AUTH_USER" ] && [ -n "$HTTP_AUTH_PASSWORD" ]; then
     echo "Setup HTTP Basic Auth..."
-    echo "$HTTP_AUTH_USER:$(printf '%s' "$HTTP_AUTH_PASSWORD" | openssl passwd -bcrypt -stdin)" > /etc/nginx/.htpasswd
+    htpasswd -nbB "$HTTP_AUTH_USER" "$HTTP_AUTH_PASSWORD" > /etc/nginx/.htpasswd
     sed -i 's/AUTH_BASIC_SETTING/"Restricted"/g' /etc/nginx/http.d/default.conf
 else
     echo "No (optional) HTTP Basic Auth configured"


### PR DESCRIPTION
Hi there! 👋\n\nI ran into the exact same startup failure reported in #269 while spinning up FossFLOW with HTTP Basic Auth enabled. The Alpine-based image doesn't ship an OpenSSL build that supports \"openssl passwd -bcrypt\", so the container bails out during entrypoint execution.\n\n**What this PR does**\n- Installs \"apache2-utils\" in the production image (provides \"htpasswd\").\n- Replaces the failing \"openssl passwd -bcrypt -stdin\" call with \"htpasswd -nbB \"\\" \"\\"\".\n\n**Why htpasswd?**\n- It is available in the Alpine package repo and generates proper bcrypt hashes out of the box (-B flag).\n- The output format (\"user:encryptedpw\") is exactly what nginx's auth_basic module expects.\n\nI verified the change builds cleanly and the container starts successfully with auth vars set. Happy to adjust anything if you prefer a different approach! 😊\n\nCloses #269