### PR TITLE
fix: add some click event stopPropagation to more UI elements to avoid unintended panning of view

### DIFF
--- a/packages/fossflow-lib/src/components/ItemControls/components/ControlsContainer.tsx
+++ b/packages/fossflow-lib/src/components/ItemControls/components/ControlsContainer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Divider } from '@mui/material';
+import { clickStopperProps } from 'src/utils';
 
 interface Props {
   header?: React.ReactNode;
@@ -9,8 +10,7 @@ interface Props {
 export const ControlsContainer = ({ header, children }: Props) => {
   return (
     <Box
-      onMouseDown={e => e.stopPropagation()}
-      onContextMenu={e => e.stopPropagation()}
+      {...clickStopperProps}
       sx={{
         position: 'relative',
         height: '100%',

--- a/packages/fossflow-lib/src/components/SettingsDialog/SettingsDialog.tsx
+++ b/packages/fossflow-lib/src/components/SettingsDialog/SettingsDialog.tsx
@@ -19,6 +19,7 @@ import { LabelSettings } from '../LabelSettings/LabelSettings';
 import { ConnectorSettings } from '../ConnectorSettings/ConnectorSettings';
 import { IconPackSettings } from '../IconPackSettings/IconPackSettings';
 import { useTranslation } from 'src/stores/localeStore';
+import { clickStopperProps } from 'src/utils';
 
 export interface SettingsDialogProps {
   iconPackManager?: {
@@ -59,6 +60,7 @@ export const SettingsDialog = ({ iconPackManager }: SettingsDialogProps) => {
       onClose={handleClose}
       maxWidth="md"
       fullWidth
+      {...clickStopperProps}
     >
       <DialogTitle>
         Settings

--- a/packages/fossflow-lib/src/components/UiElement/UiElement.tsx
+++ b/packages/fossflow-lib/src/components/UiElement/UiElement.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Card, SxProps } from '@mui/material';
+import { clickStopperProps } from 'src/utils';
 
 interface Props {
   children: React.ReactNode;
@@ -18,6 +19,7 @@ export const UiElement = ({ children, sx, style }: Props) => {
         ...sx
       }}
       style={style}
+      {...clickStopperProps}
     >
       {children}
     </Card>

--- a/packages/fossflow-lib/src/utils/clickStopperProps.ts
+++ b/packages/fossflow-lib/src/utils/clickStopperProps.ts
@@ -1,0 +1,4 @@
+export const clickStopperProps = {
+    onMouseDown: (e:React.MouseEvent<HTMLDivElement, MouseEvent>) => e.stopPropagation(),
+    onContextMenu: (e:React.MouseEvent<HTMLDivElement, MouseEvent>) => e.stopPropagation()
+}

--- a/packages/fossflow-lib/src/utils/index.ts
+++ b/packages/fossflow-lib/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from './pointInPolygon';
 export * from './connectorLabels';
 export * from './copyPaste';
 export * from './connectorGroups';
+export * from './clickStopperProps';


### PR DESCRIPTION

## What does this PR do?
PR #199 fixed the same issue but only for the item controls dialog. Turns out there are more UI components like the dropdown menu (top left) and the settings dialog, where the mousedown events arent stopped, causing the view behind the dialog/element to pan while changing sliders. In this PR, I've applied the stopPropagation to those remaining components.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have tested these changes locally and they work
- [x] I can explain every line of code in this PR if asked
- [x] This PR does not contain AI-generated code that I haven't personally reviewed, understood, and tested
- [x] I have not added any unnecessary comments, logging, or dead code
- [x] My code follows the existing style and conventions of the project
- [x] I have updated documentation if applicable

## How to test

<!-- Steps for the maintainer to verify this works: -->

1. Open settings
2. Change any setting using a slider. The view behind will not pan after this fix.

## Screenshots (if UI change)
This was the bug before, which this PR fixes
![pan bug](https://github.com/user-attachments/assets/45fe28fc-691d-4011-b403-0ecfca39e027)

