### PR TITLE
fix: resolve quilljs error logged to console

### DIFF
--- a/packages/fossflow-lib/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/packages/fossflow-lib/src/components/RichTextEditor/RichTextEditor.tsx
@@ -34,7 +34,6 @@ const formats = [
   'link',
   'header',
   'list',
-  'bullet',
   'blockquote',
   'code-block'
 ];


### PR DESCRIPTION
## What does this PR do?
Removes the 'bullet' option from the formats array for the ReactQuill component, fixing the error logged to console. Turns out we dont need to specify 'bullet', inputting bullet points still work.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have tested these changes locally and they work
- [x] I can explain every line of code in this PR if asked
- [x] This PR does not contain AI-generated code that I haven't personally reviewed, understood, and tested
- [x] I have not added any unnecessary comments, logging, or dead code
- [x] My code follows the existing style and conventions of the project
- [x] I have updated documentation if applicable

## How to test

To see the error log (before applying this fix):
1. Open browser console
2. Select any node, which will open the description textarea
3. Error is logged to console

## Screenshots (if UI change)
The error:
<img width="659" height="48" alt="image" src="https://github.com/user-attachments/assets/57fa738d-0f0c-48a6-88d9-98a03c158e9f" />

