### PR TITLE
fix: prevent infinite re-renders

### DIFF
--- a/packages/fossflow-app/src/EditorPage.tsx
+++ b/packages/fossflow-app/src/EditorPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Isoflow } from 'fossflow';
 import { flattenCollections } from '@isoflow/isopacks/dist/utils';
@@ -204,7 +204,7 @@ function EditorPage() {
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [hasUnsavedChanges, isReadonlyUrl]);
 
-  const handleModelUpdated = (model: any) => {
+  const handleModelUpdated = useCallback((model: any) => {
     const updatedData = {
       ...diagramData,
       ...model
@@ -215,7 +215,24 @@ function EditorPage() {
     if (!isReadonlyUrl) {
       setHasUnsavedChanges(true);
     }
-  };
+  }, [diagramData, isReadonlyUrl]);
+
+  // Memoize the iconPackManager prop so its reference is stable between renders.
+  // An unstable reference triggers setIconPackManager in Isoflow's useEffect every
+  // render, which causes the "Maximum update depth exceeded" infinite loop.
+  const iconPackManagerProp = useMemo(() => ({
+    lazyLoadingEnabled: iconPackManager.lazyLoadingEnabled,
+    packInfo: Object.values(iconPackManager.packInfo),
+    enabledPacks: iconPackManager.enabledPacks,
+    onToggleLazyLoading: iconPackManager.toggleLazyLoading,
+    onTogglePack: iconPackManager.togglePack
+  }), [
+    iconPackManager.lazyLoadingEnabled,
+    iconPackManager.packInfo,
+    iconPackManager.enabledPacks,
+    iconPackManager.toggleLazyLoading,
+    iconPackManager.togglePack
+  ]);
 
   const saveDiagram = () => {
     if (!diagramName.trim()) {
@@ -441,12 +458,7 @@ function EditorPage() {
           initialData={diagramData}
           onModelUpdated={handleModelUpdated}
           editorMode={isReadonlyUrl ? 'EXPLORABLE_READONLY' : 'EDITABLE'}
-          icons={iconPackManager.icons}
-          config={{
-            onTogglePack: (packName: string, enabled: boolean) => {
-              iconPackManager.togglePack(packName as any, enabled);
-            }
-          }}
+          iconPackManager={iconPackManagerProp}
         />
       </div>
 

--- a/packages/fossflow-app/src/services/iconPackManager.ts
+++ b/packages/fossflow-app/src/services/iconPackManager.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { flattenCollections } from '@isoflow/isopacks/dist/utils';
 
 // Available icon packs (excluding core isoflow which is always loaded)
@@ -100,11 +100,22 @@ export const useIconPackManager = (coreIcons: any[]) => {
 
   const [loadedIcons, setLoadedIcons] = useState<any[]>(coreIcons);
   const [loadedPackData, setLoadedPackData] = useState<Record<IconPackName, any>>({} as Record<IconPackName, any>);
+  const loadedPackDataRef = useRef(loadedPackData);
+  useEffect(() => {
+    loadedPackDataRef.current = loadedPackData;
+  }, [loadedPackData]);
 
-  // Load a specific pack
+  // Keep a stable ref to packInfo so callbacks don't need it as a dep
+  const packInfoRef = useRef(packInfo);
+  useEffect(() => {
+    packInfoRef.current = packInfo;
+  }, [packInfo]);
+
+  // Load a specific pack — stable reference, reads packInfo via ref
   const loadPack = useCallback(async (packName: IconPackName) => {
     // Already loaded?
-    if (packInfo[packName].loaded || packInfo[packName].loading) {
+    const currentInfo = packInfoRef.current;
+    if (currentInfo[packName].loaded || currentInfo[packName].loading) {
       return;
     }
 
@@ -152,35 +163,40 @@ export const useIconPackManager = (coreIcons: any[]) => {
       }));
       throw error;
     }
-  }, [packInfo]);
+  }, []); // stable — reads packInfo via ref, writes via functional setters
 
-  // Enable/disable a pack
+  // Enable/disable a pack — stable ref, reads state via refs
   const togglePack = useCallback(async (packName: IconPackName, enabled: boolean) => {
     if (enabled) {
-      // Add to enabled packs
-      const newEnabledPacks = [...enabledPacks, packName];
-      setEnabledPacks(newEnabledPacks);
-      saveEnabledPacks(newEnabledPacks);
+      // Add to enabled packs (use functional setter to avoid stale closure)
+      setEnabledPacks(prev => {
+        const newEnabledPacks = [...prev, packName];
+        saveEnabledPacks(newEnabledPacks);
+        return newEnabledPacks;
+      });
 
       // Load the pack
       await loadPack(packName);
     } else {
       // Remove from enabled packs
-      const newEnabledPacks = enabledPacks.filter(p => p !== packName);
-      setEnabledPacks(newEnabledPacks);
-      saveEnabledPacks(newEnabledPacks);
+      setEnabledPacks(prev => {
+        const newEnabledPacks = prev.filter(p => p !== packName);
+        saveEnabledPacks(newEnabledPacks);
 
-      // Remove icons from loaded icons
-      // We need to rebuild the icons array from core + enabled packs
-      const newIcons = [coreIcons];
-      for (const pack of newEnabledPacks) {
-        if (loadedPackData[pack]) {
-          newIcons.push(flattenCollections([loadedPackData[pack]]));
+        // Rebuild icons from core + remaining enabled packs
+        const currentPackData = loadedPackDataRef.current;
+        const newIcons = [coreIcons];
+        for (const pack of newEnabledPacks) {
+          if (currentPackData[pack]) {
+            newIcons.push(flattenCollections([currentPackData[pack]]));
+          }
         }
-      }
-      setLoadedIcons(newIcons.flat());
+        setLoadedIcons(newIcons.flat());
+
+        return newEnabledPacks;
+      });
     }
-  }, [enabledPacks, loadPack, coreIcons, loadedPackData]);
+  }, [loadPack, coreIcons]);
 
   // Toggle lazy loading
   const toggleLazyLoading = useCallback((enabled: boolean) => {
@@ -192,11 +208,18 @@ export const useIconPackManager = (coreIcons: any[]) => {
   const loadAllPacks = useCallback(async () => {
     const allPacks: IconPackName[] = ['aws', 'gcp', 'azure', 'kubernetes'];
     for (const pack of allPacks) {
-      if (!packInfo[pack].loaded && !packInfo[pack].loading) {
+      const info = packInfoRef.current;
+      if (!info[pack].loaded && !info[pack].loading) {
         await loadPack(pack);
       }
     }
-  }, [packInfo, loadPack]);
+  }, [loadPack]);
+
+  // Keep a stable ref to enabledPacks so loadPacksForDiagram doesn't re-create on every pack toggle
+  const enabledPacksRef = useRef(enabledPacks);
+  useEffect(() => {
+    enabledPacksRef.current = enabledPacks;
+  }, [enabledPacks]);
 
   // Auto-detect required packs from diagram data
   const loadPacksForDiagram = useCallback(async (diagramItems: any[]) => {
@@ -216,7 +239,8 @@ export const useIconPackManager = (coreIcons: any[]) => {
       if (collection !== 'isoflow' && collection !== 'imported') {
         const packName = collection as IconPackName;
         if (['aws', 'gcp', 'azure', 'kubernetes'].includes(packName)) {
-          if (!packInfo[packName].loaded && !packInfo[packName].loading) {
+          const info = packInfoRef.current;
+          if (!info[packName].loaded && !info[packName].loading) {
             packsToLoad.push(packName);
           }
         }
@@ -227,13 +251,14 @@ export const useIconPackManager = (coreIcons: any[]) => {
     for (const pack of packsToLoad) {
       await loadPack(pack);
       // Also add to enabled packs
-      if (!enabledPacks.includes(pack)) {
-        const newEnabledPacks = [...enabledPacks, pack];
+      const currentEnabledPacks = enabledPacksRef.current;
+      if (!currentEnabledPacks.includes(pack)) {
+        const newEnabledPacks = [...currentEnabledPacks, pack];
         setEnabledPacks(newEnabledPacks);
         saveEnabledPacks(newEnabledPacks);
       }
     }
-  }, [packInfo, enabledPacks, loadPack]);
+  }, [loadPack]);
 
   // Initialize: Load enabled packs or all packs depending on lazy loading setting
   useEffect(() => {
@@ -242,15 +267,17 @@ export const useIconPackManager = (coreIcons: any[]) => {
         // Load all packs immediately
         await loadAllPacks();
       } else {
-        // Load only enabled packs
-        for (const pack of enabledPacks) {
-          if (!packInfo[pack].loaded && !packInfo[pack].loading) {
+        // Load only enabled packs (read from ref to avoid stale closure)
+        for (const pack of enabledPacksRef.current) {
+          const info = packInfoRef.current;
+          if (!info[pack].loaded && !info[pack].loading) {
             await loadPack(pack);
           }
         }
       }
     };
     initialize();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run once on mount
 
   return {

--- a/packages/fossflow-lib/src/hooks/useHistory.ts
+++ b/packages/fossflow-lib/src/hooks/useHistory.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useMemo } from 'react';
 import { useModelStore } from 'src/stores/modelStore';
 import { useSceneStore } from 'src/stores/sceneStore';
 
@@ -114,16 +114,19 @@ export const useHistory = () => {
     sceneActions.clearHistory();
   }, [modelActions, sceneActions]);
 
-  return {
-    undo,
-    redo,
-    canUndo,
-    canRedo,
-    saveToHistory,
-    clearHistory,
-    transaction,
-    isInTransaction: () => {
-      return transactionInProgress.current;
-    }
-  };
+  return useMemo(
+    () => ({
+      undo,
+      redo,
+      canUndo,
+      canRedo,
+      saveToHistory,
+      clearHistory,
+      transaction,
+      isInTransaction: () => {
+        return transactionInProgress.current;
+      }
+    }),
+    [undo, redo, canUndo, canRedo, saveToHistory, clearHistory, transaction]
+  );
 };

--- a/packages/fossflow-lib/src/hooks/useScene.ts
+++ b/packages/fossflow-lib/src/hooks/useScene.ts
@@ -425,114 +425,186 @@ export const useScene = () => {
     [createModelItem, createViewItem, saveToHistoryBeforeChange]
   );
 
-  const copyObjectsToClipboard = (uiState: UiStateStore) => {
-    const model = modelStoreApi.getState()
-    const selectedObjects = (
-      uiState.mode.type === 'LASSO' ||
-      uiState.mode.type === 'FREEHAND_LASSO'
-    ) && uiState.mode.selection ?
-      uiState.mode.selection.items
-      :
-      [uiState.itemControls && 'id' in uiState.itemControls ? (uiState.itemControls as ItemReference) : null].filter(Boolean) as ItemReference[];
+  const copyObjectsToClipboard = useCallback(
+    (uiState: UiStateStore) => {
+      const model = modelStoreApi.getState();
+      const selectedObjects =
+        (uiState.mode.type === 'LASSO' ||
+          uiState.mode.type === 'FREEHAND_LASSO') &&
+        uiState.mode.selection
+          ? uiState.mode.selection.items
+          : [
+              uiState.itemControls && 'id' in uiState.itemControls
+                ? (uiState.itemControls as ItemReference)
+                : null
+            ].filter(Boolean) as ItemReference[];
 
-    copyObject(selectedObjects.map((currentItem) => {
-      if (!currentItem) return;
-      switch (currentItem.type) {
-        case 'ITEM': {
-          const modelItem = getItemById(model.items, currentItem.id)?.value;
-          const viewItem = getItemById(currentView.items, currentItem.id)?.value;
-          if (!viewItem || !modelItem) return;
+      copyObject(
+        selectedObjects.map((currentItem) => {
+          if (!currentItem) return;
+          switch (currentItem.type) {
+            case 'ITEM': {
+              const modelItem = getItemById(model.items, currentItem.id)?.value;
+              const viewItem = getItemById(currentView.items, currentItem.id)
+                ?.value;
+              if (!viewItem || !modelItem) return;
 
-          return { type: currentItem.type, item: { modelItem, viewItem } }
-        }
-        case 'RECTANGLE': {
-          if (!currentView.rectangles) return;
-          const item = getItemById(currentView.rectangles, currentItem.id)?.value;
-          return { type: currentItem.type, item }
-        }
-        case 'TEXTBOX': {
-          if (!currentView.textBoxes) return;
-          const item = getItemById(currentView.textBoxes, currentItem.id)?.value;
-          return { type: currentItem.type, item }
-        }
+              return { type: currentItem.type, item: { modelItem, viewItem } };
+            }
+            case 'RECTANGLE': {
+              if (!currentView.rectangles) return;
+              const item = getItemById(currentView.rectangles, currentItem.id)
+                ?.value;
+              return { type: currentItem.type, item };
+            }
+            case 'TEXTBOX': {
+              if (!currentView.textBoxes) return;
+              const item = getItemById(currentView.textBoxes, currentItem.id)
+                ?.value;
+              return { type: currentItem.type, item };
+            }
+          }
+        })
+      );
+    },
+    [
+      modelStoreApi,
+      currentView.items,
+      currentView.rectangles,
+      currentView.textBoxes
+    ]
+  );
+
+  const pasteObjectsFromClipboard: (
+    uiState: UiStateStore,
+    activeScene: ReturnType<typeof useScene>
+  ) => Promise<void> = useCallback(
+    async (uiState, activeScene) => {
+      const pastedArray = await getPastedObject();
+      if (!isPastedValid(pastedArray)) return;
+
+      saveToHistoryBeforeChange();
+      transactionInProgress.current = true;
+
+      try {
+        const mouseTile = uiState.mouse.position.tile;
+        const getTargetTile = getTargetTileFunction(
+          pastedArray[0],
+          mouseTile,
+          activeScene
+        );
+        let state: State | undefined;
+
+        pastedArray.forEach((pastedObject) => {
+          const newId = generateId();
+
+          if (pastedObject.type === 'ITEM') {
+            const { viewItem, modelItem } = pastedObject.item;
+            const stateWithNewModel = createModelItem(
+              {
+                ...modelItem,
+                id: newId
+              },
+              state
+            );
+
+            // Chain updated state from each iteration
+            state = createViewItem(
+              {
+                ...viewItem,
+                id: newId,
+                tile: getTargetTile(viewItem.tile)
+              },
+              stateWithNewModel
+            );
+          } else if (pastedObject.type === 'RECTANGLE') {
+            state = createRectangle(
+              {
+                ...pastedObject.item,
+                id: newId,
+                from: getTargetTile(pastedObject.item.from),
+                to: getTargetTile(pastedObject.item.to)
+              },
+              state
+            );
+          } else if (pastedObject.type === 'TEXTBOX') {
+            state = createTextBox(
+              {
+                ...pastedObject.item,
+                id: newId,
+                tile: getTargetTile(pastedObject.item.tile)
+              },
+              state
+            );
+          }
+        });
+      } finally {
+        transactionInProgress.current = false;
       }
-    }));
-  }
+    },
+    [
+      saveToHistoryBeforeChange,
+      createModelItem,
+      createViewItem,
+      createRectangle,
+      createTextBox
+    ]
+  );
 
-  const pasteObjectsFromClipboard: (uiState: UiStateStore, activeScene: ReturnType<typeof useScene>) => Promise<void> = 
-  async (uiState, activeScene) => {
-    const pastedArray = await getPastedObject();
-    if (!isPastedValid(pastedArray)) return;
-
-    saveToHistoryBeforeChange();
-    transactionInProgress.current = true;
-
-    try {
-      const mouseTile = uiState.mouse.position.tile;
-      const getTargetTile = getTargetTileFunction(pastedArray[0], mouseTile, activeScene);
-      let state: State | undefined;
-  
-      pastedArray.forEach(pastedObject => {
-        const newId = generateId();
-  
-        if (pastedObject.type === 'ITEM') {
-          const { viewItem, modelItem } = pastedObject.item;
-          const stateWithNewModel = createModelItem({
-            ...modelItem,
-            id: newId
-          }, state)
-          
-          // Chain updated state from each iteration
-          state = createViewItem({
-            ...viewItem,
-            id: newId,
-            tile: getTargetTile(viewItem.tile)
-          }, stateWithNewModel)
-        } else if (pastedObject.type === 'RECTANGLE') {
-          state = createRectangle({
-            ...pastedObject.item, 
-            id: newId,
-            from: getTargetTile(pastedObject.item.from),
-            to: getTargetTile(pastedObject.item.to)
-          }, state)
-        } else if (pastedObject.type === "TEXTBOX") {
-          state = createTextBox({
-            ...pastedObject.item, 
-            id: newId,
-            tile: getTargetTile(pastedObject.item.tile)
-          }, state);
-        }
-      })
-    } finally {
-      transactionInProgress.current = false;
-    }
-  }
-
-  return {
-    items: itemsList,
-    connectors: connectorsList,
-    colors: colorsList,
-    rectangles: rectanglesList,
-    textBoxes: textBoxesList,
-    currentView,
-    createModelItem,
-    updateModelItem,
-    deleteModelItem,
-    createViewItem,
-    updateViewItem,
-    deleteViewItem,
-    createConnector,
-    updateConnector,
-    deleteConnector,
-    createTextBox,
-    updateTextBox,
-    deleteTextBox,
-    createRectangle,
-    updateRectangle,
-    deleteRectangle,
-    transaction,
-    placeIcon,
-    copyObjectsToClipboard,
-    pasteObjectsFromClipboard,
-  };
+  return useMemo(
+    () => ({
+      items: itemsList,
+      connectors: connectorsList,
+      colors: colorsList,
+      rectangles: rectanglesList,
+      textBoxes: textBoxesList,
+      currentView,
+      createModelItem,
+      updateModelItem,
+      deleteModelItem,
+      createViewItem,
+      updateViewItem,
+      deleteViewItem,
+      createConnector,
+      updateConnector,
+      deleteConnector,
+      createTextBox,
+      updateTextBox,
+      deleteTextBox,
+      createRectangle,
+      updateRectangle,
+      deleteRectangle,
+      transaction,
+      placeIcon,
+      copyObjectsToClipboard,
+      pasteObjectsFromClipboard
+    }),
+    [
+      itemsList,
+      connectorsList,
+      colorsList,
+      rectanglesList,
+      textBoxesList,
+      currentView,
+      createModelItem,
+      updateModelItem,
+      deleteModelItem,
+      createViewItem,
+      updateViewItem,
+      deleteViewItem,
+      createConnector,
+      updateConnector,
+      deleteConnector,
+      createTextBox,
+      updateTextBox,
+      deleteTextBox,
+      createRectangle,
+      updateRectangle,
+      deleteRectangle,
+      transaction,
+      placeIcon,
+      copyObjectsToClipboard,
+      pasteObjectsFromClipboard
+    ]
+  );
 };

--- a/packages/fossflow-lib/src/hooks/useView.ts
+++ b/packages/fossflow-lib/src/hooks/useView.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useUiStateStore } from 'src/stores/uiStateStore';
 import { useSceneStore } from 'src/stores/sceneStore';
 import * as reducers from 'src/stores/reducers';
@@ -28,7 +28,10 @@ export const useView = () => {
     [uiStateActions, sceneActions]
   );
 
-  return {
-    changeView
-  };
+  return useMemo(
+    () => ({
+      changeView
+    }),
+    [changeView]
+  );
 };


### PR DESCRIPTION
What does this PR do?
Resolves a Warning: Maximum update depth exceeded error that was repeatedly logged to the console after opening the context menu on a dev build.
The root cause was a chain of unstable React references:
1. loadPack in useIconPackManager had packInfo in its useCallback deps. Every time a pack loaded, packInfo updated -> new loadPack reference -> new togglePack, loadAllPacks, etc. references.
2. EditorPage passed an inline config object to <Isoflow> on every render. Inside Isoflow, a useEffect watching iconPackManager called setIconPackManager on every render -> store update -> re-render -> repeat.

The fix breaks both cycles: useRef bridges replace state reads inside callbacks (making them stable), and useMemo/ useCallback stabilise the props passed to <Isoflow>. Additionally, the return objects to useScene, useHistory and useView are now memoized, preventing cascading re-renders across the diagram engine.
Fixes #295 

Type of Change: Bug fix

Checklist
 I have read CONTRIBUTING.md
 I have tested these changes locally, and they work
 I can explain every line of code in this PR if asked
 This PR does not contain AI-generated code that I haven't personally reviewed, understood, and tested
 I have not added any unnecessary comments, logging, or dead code
 My code follows the existing style and conventions of the project
 I have updated the documentation if applicable

How to test
1. Open FossFLOW locally run: npm run dev:lib and npm run dev
2. Open the browser console (F12 -> console tab) and clear it
3. Right-click on any tile in the canvas to open the context menu
4. Verify that no Warning: Maximum update depth exceeded errors appear in the console

Screenshots: N/A - this is a runtime error fix with no visual change.
