### PR TITLE
feat: enable panning from other modes

### DIFF
--- a/packages/fossflow-lib/src/components/PanSettings/PanSettings.tsx
+++ b/packages/fossflow-lib/src/components/PanSettings/PanSettings.tsx
@@ -56,7 +56,7 @@ export const PanSettings = () => {
         <FormControlLabel
           control={
             <Switch
-              checked={!panSettings.middleClickPan}
+              checked={panSettings.middleClickPan}
               onChange={() => handleToggle('middleClickPan')}
             />
           }
@@ -66,7 +66,7 @@ export const PanSettings = () => {
         <FormControlLabel
           control={
             <Switch
-              checked={!panSettings.rightClickPan}
+              checked={panSettings.rightClickPan}
               onChange={() => handleToggle('rightClickPan')}
             />
           }
@@ -76,7 +76,7 @@ export const PanSettings = () => {
         <FormControlLabel
           control={
             <Switch
-              checked={!panSettings.ctrlClickPan}
+              checked={panSettings.ctrlClickPan}
               onChange={() => handleToggle('ctrlClickPan')}
             />
           }
@@ -86,7 +86,7 @@ export const PanSettings = () => {
         <FormControlLabel
           control={
             <Switch
-              checked={!panSettings.altClickPan}
+              checked={panSettings.altClickPan}
               onChange={() => handleToggle('altClickPan')}
             />
           }

--- a/packages/fossflow-lib/src/interaction/modes/Pan.ts
+++ b/packages/fossflow-lib/src/interaction/modes/Pan.ts
@@ -3,8 +3,12 @@ import { CoordsUtils, setWindowCursor } from 'src/utils';
 import { ModeActions } from 'src/types';
 
 export const Pan: ModeActions = {
-  entry: () => {
-    setWindowCursor('grab');
+  entry: ({ uiState }) => {
+    if (uiState.mode.type === 'PAN' && uiState.mode.temp) {
+      setWindowCursor('grabbing');
+    } else {
+      setWindowCursor('grab');
+    }
   },
   exit: () => {
     setWindowCursor('default');
@@ -12,7 +16,7 @@ export const Pan: ModeActions = {
   mousemove: ({ uiState }) => {
     if (uiState.mode.type !== 'PAN') return;
 
-    if (uiState.mouse.mousedown !== null) {
+    if (uiState.mode.temp || uiState.mouse.mousedown !== null) {
       const newScroll = produce(uiState.scroll, (draft) => {
         draft.position = uiState.mouse.delta?.screen
           ? CoordsUtils.add(draft.position, uiState.mouse.delta.screen)

--- a/packages/fossflow-lib/src/interaction/useInteractionManager.ts
+++ b/packages/fossflow-lib/src/interaction/useInteractionManager.ts
@@ -282,16 +282,21 @@ export const useInteractionManager = () => {
   }, [undo, redo, canUndo, canRedo, uiStateApi, createTextBox, scene]);
 
   const processMouseUpdate = useCallback(
-    (nextMouse: Mouse, e: SlimMouseEvent) => {
+    (nextMouse: Mouse, e: SlimMouseEvent, skipModeUpdate?: boolean) => {
       if (!rendererRef.current) return;
 
       const uiState = uiStateApi.getState();
-      const model = modelStoreApi.getState();
+
+      if (skipModeUpdate) {
+        uiState.actions.setMouse(nextMouse);
+        return;
+      }
 
       const mode = modes[uiState.mode.type];
       const modeFunction = getModeFunction(mode, e);
-
       if (!modeFunction) return;
+      
+      const model = modelStoreApi.getState();
 
       uiState.actions.setMouse(nextMouse);
 
@@ -328,13 +333,6 @@ export const useInteractionManager = () => {
     (e: SlimMouseEvent) => {
       if (!rendererRef.current) return;
 
-      if (e.type === 'mousedown' && handlePanMouseDown(e)) {
-        return;
-      }
-      if (e.type === 'mouseup' && handlePanMouseUp(e)) {
-        return;
-      }
-
       const uiState = uiStateApi.getState();
 
       const nextMouse = getMouse({
@@ -352,7 +350,10 @@ export const useInteractionManager = () => {
         });
       } else {
         flushUpdate();
-        processMouseUpdate(nextMouse, e);
+        processMouseUpdate(nextMouse, e, 
+          (e.type === 'mousedown' && handlePanMouseDown(e)) ||
+          (e.type === 'mouseup' && handlePanMouseUp(e))
+        );
       }
     },
     [uiStateApi, rendererSize, handlePanMouseDown, handlePanMouseUp, scheduleUpdate, flushUpdate, processMouseUpdate]

--- a/packages/fossflow-lib/src/interaction/usePanHandlers.ts
+++ b/packages/fossflow-lib/src/interaction/usePanHandlers.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useUiStateStore, useUiStateStoreApi } from 'src/stores/uiStateStore';
 import { CoordsUtils, getItemAtTile } from 'src/utils';
 import { useScene } from 'src/hooks/useScene';

--- a/packages/fossflow-lib/src/interaction/usePanHandlers.ts
+++ b/packages/fossflow-lib/src/interaction/usePanHandlers.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useUiStateStore, useUiStateStoreApi } from 'src/stores/uiStateStore';
 import { CoordsUtils, getItemAtTile } from 'src/utils';
 import { useScene } from 'src/hooks/useScene';
@@ -13,15 +13,16 @@ export const usePanHandlers = () => {
   const uiStateApi = useUiStateStoreApi();
   const scene = useScene();
   const isPanningRef = useRef(false);
-  const panMethodRef = useRef<string | null>(null);
+  const prevModeRef = useRef(uiStateApi.getState().mode);
 
-  const startPan = useCallback((method: string) => {
+  const startPan = useCallback(() => {
     if (modeType !== 'PAN') {
       isPanningRef.current = true;
-      panMethodRef.current = method;
+      prevModeRef.current = uiStateApi.getState().mode;
       actions.setMode({
         type: 'PAN',
-        showCursor: false
+        showCursor: false,
+        temp: true
       });
     }
   }, [modeType, actions]);
@@ -29,14 +30,9 @@ export const usePanHandlers = () => {
   const endPan = useCallback(() => {
     if (isPanningRef.current) {
       isPanningRef.current = false;
-      panMethodRef.current = null;
-      actions.setMode({
-        type: 'CURSOR',
-        showCursor: true,
-        mousedownItem: null
-      });
+      actions.setMode(prevModeRef.current);
     }
-  }, [actions]);
+  }, [modeType, actions]);
 
   const isEmptyArea = useCallback((e: SlimMouseEvent): boolean => {
     if (!rendererEl || e.target !== rendererEl) return false;
@@ -50,37 +46,18 @@ export const usePanHandlers = () => {
   }, [rendererEl, mouseTile, scene]);
 
   const handleMouseDown = useCallback((e: SlimMouseEvent): boolean => {
-    if (e.button === 1 && panSettings.middleClickPan) {
+    if (
+      (e.button === 1 && panSettings.middleClickPan) ||
+      (e.button === 2 && panSettings.rightClickPan) ||
+      (e.button === 0) && (
+        (panSettings.ctrlClickPan && e.ctrlKey) ||
+        (panSettings.altClickPan && e.altKey) ||
+        (panSettings.emptyAreaClickPan && isEmptyArea(e))
+      )) {
       e.preventDefault();
-      startPan('middle');
+      startPan();
       return true;
     }
-
-    if (e.button === 2 && panSettings.rightClickPan) {
-      e.preventDefault();
-      startPan('right');
-      return true;
-    }
-
-    if (e.button === 0) {
-      if (panSettings.ctrlClickPan && e.ctrlKey) {
-        e.preventDefault();
-        startPan('ctrl');
-        return true;
-      }
-
-      if (panSettings.altClickPan && e.altKey) {
-        e.preventDefault();
-        startPan('alt');
-        return true;
-      }
-
-      if (panSettings.emptyAreaClickPan && isEmptyArea(e)) {
-        startPan('empty');
-        return true;
-      }
-    }
-
     return false;
   }, [panSettings, startPan, isEmptyArea]);
 

--- a/packages/fossflow-lib/src/types/ui.ts
+++ b/packages/fossflow-lib/src/types/ui.ts
@@ -56,6 +56,7 @@ export interface DragItemsMode {
 export interface PanMode {
   type: 'PAN';
   showCursor: boolean;
+  temp?: boolean; // For panning temporarily from other modes
 }
 
 export interface PlaceIconMode {


### PR DESCRIPTION
## What does this PR do?
Looks like some progress has already been made for this before by you?
This PR completes this feature - meaning users can pan while in other modes using any of Ctrl+click, Alt+click, middle click - based on what is enabled in the Pan Settings.

Fixes #153 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional change)
- [ ] Documentation update

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have tested these changes locally and they work
- [x] I can explain every line of code in this PR if asked
- [x] This PR does not contain AI-generated code that I haven't personally reviewed, understood, and tested
- [x] I have not added any unnecessary comments, logging, or dead code
- [x] My code follows the existing style and conventions of the project
- [ ] I have updated documentation if applicable

## How to test

1. Choose any mode other than pan
2. Pan by clicking the scroll wheel (enabled by default) or ctr+click or alt+click after enabling from Pan Settings
3. Mode should change to the previous one after mouseup

## Screenshots (if UI change)
Demo using connector tool
<img width="620" height="422" alt="pan-with-middle-click" src="https://github.com/user-attachments/assets/cb469a67-a2b7-4717-8edb-0e19b2df15cc" />
