### PR TITLE
fix: add explicit permissions blocks to CI workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,10 @@ on:
       - completed
     branches: ["main", "master"]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,15 +1,16 @@
 name: E2E Tests
 
 on:
-  # Runs on PRs so we can gate merges on E2E results
   pull_request:
     branches: ["main", "master"]
-  # Runs after unit tests complete successfully on push
   workflow_run:
     workflows: ["Run Tests"]
     types:
       - completed
     branches: ["main", "master"]
+
+permissions:
+  contents: read
 
 jobs:
   e2e-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main", "master"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Added explicit `permissions:` blocks to `test.yml`, `docker.yml`, and `e2e-tests.yml` — each scoped to `contents: read` (plus `packages: write` for Docker).
- Workflows that already had permissions (`release.yml`, `pages.yml`, `dependabot-automerge.yml`, `ethicalcheck.yml`) were left unchanged.

Resolves 3 open CodeQL `actions/missing-workflow-permissions` findings.