### PR TITLE
chore: bump Node.js to 24 across all workflows and Dockerfile

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: 'npm'
 
       - name: Setup Python

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Build
-        uses: docker://node:22-alpine
+        uses: docker://node:24-alpine
         with:
           args: sh -c "npm install && npm run build:lib && npm run build:app"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [24.x]
     
     steps:
       - name: Checkout code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Node.js runtime as the base image
-FROM node:22 AS build
+FROM node:24 AS build
 
 # Set the working directory in the container
 WORKDIR /app
@@ -22,7 +22,7 @@ COPY . .
 RUN npm run build:lib && npm run build:app
 
 # Use Node with nginx for production
-FROM node:22-alpine
+FROM node:24-alpine
 
 # Install web server packages
 RUN apk add --no-cache nginx openssl

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^5.9.3"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=24.0.0",
     "npm": ">=9.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- Bumps Node.js from 22 to **24** (current LTS) across all CI workflows, Dockerfile, and `engines` field in root `package.json`
- Collapses the test matrix from `[20.x, 22.x, 24.x]` to `[24.x]` — reduces CI minutes and avoids testing against versions the project no longer targets
- Updates: `test.yml`, `release.yml`, `e2e-tests.yml`, `pages.yml`, `Dockerfile`